### PR TITLE
Test p2p against Rust 1.41.0 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ jobs:
       script:
         - RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features molc
     - stage: Test
+      rust: 1.41.0
+      name: Unitest(molc + rust 1.41.0)
+      script:
+        - RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features molc
+    - stage: Test
       name: Bench(molc)
       script:
         - cd bench


### PR DESCRIPTION
CKB still uses 1.41.0, let's ensure p2p works with 1.41.0 via CI.