### PR TITLE
perf: reduce one copy behavior during transmission

### DIFF
--- a/secio/src/handshake/handshake_context.rs
+++ b/secio/src/handshake/handshake_context.rs
@@ -29,7 +29,7 @@ pub struct HandshakeContext<T> {
 pub struct Local {
     // Locally-generated random number. The array size can be changed without any repercussion.
     pub(crate) nonce: [u8; 16],
-    // Our local public key flatbuffer bytes:
+    // Our local public key bytes:
     pub(crate) public_key: Vec<u8>,
     // Our local proposition's raw bytes:
     pub(crate) proposition_bytes: Bytes,
@@ -150,7 +150,7 @@ impl HandshakeContext<Local> {
             }
         };
 
-        if public_key == self.config.key.public_key() {
+        if public_key.inner_ref() == &self.state.public_key {
             return Err(SecioError::ConnectSelf);
         }
 


### PR DESCRIPTION
Reduce a useless copy of secio during transmission

I write a bench code:
```rust
use criterion::{criterion_group, criterion_main, Bencher, Criterion};
use bytes::{BytesMut, Bytes, Buf};

fn bytesmut_decode_test(data: Vec<u8>) {
    let mut a = BytesMut::from(data.as_slice());
    a.advance(16);
    let a  = a.split_to(a.len()- 1);
}

fn vec_decode_test(mut data: Vec<u8>) {
    let mut a = data.split_off(16);
    let a = a.split_off(a.len()- 1);
}

fn vec_decode_test_drain(mut data: Vec<u8>) {
    data.drain(..16);
    data.drain(..data.len());
}

fn bytes_encode_test(data: Vec<u8>) {
    let a = BytesMut::from(data.as_slice());
    let a  = a.freeze();
}

fn vec_encode_test(data: Vec<u8>) {
    let a  = Bytes::from(data);
}

fn bench_encode_test(bench: &mut Bencher, bytes:bool, data: Vec<u8>) {
    bench.iter(|| {
        if bytes {
            bytes_encode_test(data.clone())
        } else {
            vec_encode_test(data.clone())
        }
    })
}

fn bench_decode_test(bench: &mut Bencher, bytes:bool, data: Vec<u8>) {
    bench.iter(|| {
        if bytes {
            bytesmut_decode_test(data.clone())
        } else {
            vec_decode_test(data.clone())
        }
    })
}

fn bench_decode_test_drain(bench: &mut Bencher, data: Vec<u8>) {
    bench.iter(|| {
        vec_decode_test_drain(data.clone())
    })
}

fn criterion_benchmark(bench: &mut Criterion) {
    let data = (0..1024)
        .map(|_| rand::random::<u8>())
        .collect::<Vec<_>>();

    bench.bench_function("1kb_byte_encode", {
        let data = data.clone();
        move |b| bench_encode_test(b, true, data.clone())
    });

    bench.bench_function("1kb_vec_encode", {
        let data = data.clone();
        move |b| bench_encode_test(b, false, data.clone())
    });

    bench.bench_function("1kb_bytesmut_decode", {
        let data = data.clone();
        move |b| bench_decode_test(b, true, data.clone())
    });

    bench.bench_function("1kb_vec_decode", {
        let data = data.clone();
        move |b| bench_decode_test(b, false, data.clone())
    });

    bench.bench_function("1kb_vec_decode_drain", {
        let data = data.clone();
        move |b| bench_decode_test_drain(b, data.clone())
    });

    let data = (0..1024* 1024)
    .map(|_| rand::random::<u8>())
    .collect::<Vec<_>>();

    bench.bench_function("1mb_byte_encode", {
        let data = data.clone();
        move |b| bench_encode_test(b, true, data.clone())
    });

    bench.bench_function("1mb_vec_encode", {
        let data = data.clone();
        move |b| bench_encode_test(b, false, data.clone())
    });

    bench.bench_function("1mb_bytesmut_decode", {
        let data = data.clone();
        move |b| bench_decode_test(b, true, data.clone())
    });

    bench.bench_function("1mb_vec_decode", {
        let data = data.clone();
        move |b| bench_decode_test(b, false, data.clone())
    });

    bench.bench_function("1mb_vec_decode_drain", {
        let data = data.clone();
        move |b| bench_decode_test_drain(b, data.clone())
    });
}

criterion_group!(benches, criterion_benchmark);
criterion_main!(benches);
```

it's output:
```
1kb_byte_encode         time:   [73.595 ns 74.684 ns 75.887 ns]                                                                        
                        change: [-4.2478% -3.0919% -1.9998%] (p = 0.00 < 0.05
1kb_vec_encode          time:   [31.572 ns 32.142 ns 32.800 ns]                             
                        change: [-3.4137% -2.0815% -0.7652%] (p = 0.00 < 0.05)
1kb_bytesmut_decode     time:   [88.566 ns 89.691 ns 91.327 ns]                                 
                        change: [-1.1166% +0.6703% +2.5559%] (p = 0.46 > 0.05)
1kb_vec_decode          time:   [49.910 ns 50.260 ns 50.740 ns]                            
                        change: [-1.5146% +0.3990% +2.5061%] (p = 0.69 > 0.05
1kb_vec_decode_drain    time:   [41.174 ns 41.590 ns 42.081 ns]                                                                        
                        change: [-21.425% -20.137% -18.802%] (p = 0.00 < 0.05)
1mb_byte_encode         time:   [767.41 us 775.67 us 785.65 us]                                                                        
                        change: [-1.9400% +0.0740% +1.9611%] (p = 0.94 > 0.05
1mb_vec_encode          time:   [39.493 us 39.738 us 40.018 us]                             
                        change: [-0.6507% +0.8067% +2.4188%] (p = 0.29 > 0.05
1mb_bytesmut_decode     time:   [774.91 us 790.36 us 806.37 us]                                 
                        change: [-3.9192% -2.0953% -0.3082%] (p = 0.03 < 0.05
1mb_vec_decode          time:   [757.15 us 770.60 us 786.43 us]                            
                        change: [-10.155% -8.5037% -6.6613%] (p = 0.00 < 0.05
1mb_vec_decode_drain    time:   [73.740 us 74.130 us 74.580 us]                                 
                        change: [-90.406% -90.233% -90.072%] (p = 0.00 < 0.05)
```