### PR TITLE
[BREAK CHANGE] refactor: split the big `Error` enum into a several small `ErrorKind` enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "0.2.0", features = ["time", "io-util", "tcp", "dns", "rt-th
 tokio-util = { version = "0.3.0", features = ["codec"] }
 log = "0.4"
 bytes = "0.5.0"
+thiserror = "1.0"
 
 flatbuffers = { version = "0.6.0", optional = true }
 flatbuffers-verifier = { version = "0.2.0", optional = true }

--- a/secio/src/handshake/procedure.rs
+++ b/secio/src/handshake/procedure.rs
@@ -130,7 +130,7 @@ where
     let raw_exchanges = match socket.next().await {
         Some(raw) => raw?,
         None => {
-            let err = io::Error::new(io::ErrorKind::BrokenPipe, "unexpected eof");
+            let err = io::Error::new(io::ErrorKind::UnexpectedEof, "unexpected eof");
             debug!("unexpected eof while waiting for remote's proposition");
             return Err(err.into());
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,100 +1,66 @@
 use crate::{secio::error::SecioError, SessionId};
-use futures::channel::mpsc;
-use std::{error, fmt, io};
+use multiaddr::Multiaddr;
 
-/// Error from p2p framework
 #[derive(Debug)]
-pub enum Error {
+/// Transport Error
+pub enum TransportErrorKind {
     /// IO error
-    IoError(io::Error),
-    /// Connect self
-    ConnectSelf,
+    Io(std::io::Error),
+    /// Protocol not support
+    NotSupport(Multiaddr),
+    /// Dns resolver error
+    DNSResolverError((Multiaddr, std::io::Error)),
+}
+
+#[derive(Debug)]
+/// Protocol handle error
+pub enum ProtocolHandleErrorKind {
+    /// protocol handle block, may be user's protocol handle implementation problem
+    Block(Option<SessionId>),
+    /// protocol handle abnormally closed, may be user's protocol handle implementation problem
+    AbnormallyClosed(Option<SessionId>),
+}
+
+#[derive(Debug)]
+/// Detail error kind when dial remote error
+pub enum DialerErrorKind {
+    /// IO error
+    IoError(std::io::Error),
     /// When dial remote, peer id does not match
     PeerIdNotMatch,
     /// Connected to the connected peer
     RepeatedConnection(SessionId),
     /// Handshake error
-    HandshakeError(SecioError),
-    /// DNS resolver error
-    DNSResolverError(io::Error),
-    /// protocol handle block, may be user's protocol handle implementation problem
-    ProtoHandleBlock(Option<SessionId>),
-    /// protocol handle abnormally closed, may be user's protocol handle implementation problem
-    ProtoHandleAbnormallyClosed(Option<SessionId>),
+    HandshakeError(HandshakeErrorKind),
+    /// Transport error
+    TransportError(TransportErrorKind),
 }
 
-impl PartialEq for Error {
-    fn eq(&self, other: &Error) -> bool {
-        use self::Error::*;
-        match (self, other) {
-            (ConnectSelf, ConnectSelf) | (PeerIdNotMatch, PeerIdNotMatch) => true,
-            (RepeatedConnection(i), RepeatedConnection(j)) => i == j,
-            (HandshakeError(i), HandshakeError(j)) => i == j,
-            _ => false,
-        }
-    }
+#[derive(Debug)]
+/// Handshake error
+pub enum HandshakeErrorKind {
+    /// Handshake timeout error
+    Timeout(String),
+    /// Secio error
+    SecioError(SecioError),
 }
 
-impl From<io::Error> for Error {
-    #[inline]
-    fn from(err: io::Error) -> Error {
-        Error::IoError(err)
-    }
+#[derive(Debug)]
+/// Listener error kind when dial remote error
+pub enum ListenErrorKind {
+    /// IO error
+    IoError(std::io::Error),
+    /// Connected to the connected peer
+    RepeatedConnection(SessionId),
+    /// Transport error
+    TransportError(TransportErrorKind),
 }
 
-impl From<mpsc::SendError> for Error {
-    #[inline]
-    fn from(_err: mpsc::SendError) -> Error {
-        Error::IoError(io::ErrorKind::BrokenPipe.into())
-    }
-}
-
-impl<T> From<mpsc::TrySendError<T>> for Error {
-    #[inline]
-    fn from(_err: mpsc::TrySendError<T>) -> Error {
-        Error::IoError(io::ErrorKind::BrokenPipe.into())
-    }
-}
-
-impl From<SecioError> for Error {
-    #[inline]
-    fn from(err: SecioError) -> Error {
-        match err {
-            SecioError::ConnectSelf => Error::ConnectSelf,
-            error => Error::HandshakeError(error),
-        }
-    }
-}
-
-impl error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::IoError(e) => fmt::Display::fmt(e, f),
-            Error::ConnectSelf => write!(f, "Connect self"),
-            Error::RepeatedConnection(id) => {
-                write!(f, "Connected to the connected peer, session id: [{}]", id)
-            }
-            Error::PeerIdNotMatch => write!(f, "When dial remote, peer id does not match"),
-            Error::HandshakeError(e) => fmt::Display::fmt(e, f),
-            Error::DNSResolverError(e) => write!(f, "DNs resolver error: {:?}", e),
-            Error::ProtoHandleBlock(id) => write!(
-                f,
-                "Protocol handle block{}",
-                match id {
-                    Some(id) => format!(", caused by session [{}]", id),
-                    None => "".to_string(),
-                }
-            ),
-            Error::ProtoHandleAbnormallyClosed(id) => write!(
-                f,
-                "Protocol handle abnormally closed{}",
-                match id {
-                    Some(id) => format!(", caused by session [{}]", id),
-                    None => "".to_string(),
-                }
-            ),
-        }
-    }
+#[derive(Debug)]
+/// Send error kind when send service task
+pub enum SendErrorKind {
+    /// Sending failed because a pipe was closed.
+    BrokenPipe,
+    /// The operation needs to block to complete, but the blocking operation was requested to not occur.
+    WouldBlock,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,66 +1,85 @@
 use crate::{secio::error::SecioError, SessionId};
 use multiaddr::Multiaddr;
+use std::io::Error as IOError;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Transport Error
 pub enum TransportErrorKind {
     /// IO error
-    Io(std::io::Error),
+    #[error("transport io error: `{0:?}`")]
+    Io(IOError),
     /// Protocol not support
-    NotSupport(Multiaddr),
+    #[error("multiaddr `{0:?}` is not supported")]
+    NotSupported(Multiaddr),
     /// Dns resolver error
-    DNSResolverError((Multiaddr, std::io::Error)),
+    #[error("can not resolve `{0:?}`, io error: `{1:?}`")]
+    DNSResolverError(Multiaddr, IOError),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Protocol handle error
 pub enum ProtocolHandleErrorKind {
     /// protocol handle block, may be user's protocol handle implementation problem
+    #[error("protocol handle block, session id: `{0:?}`")]
     Block(Option<SessionId>),
     /// protocol handle abnormally closed, may be user's protocol handle implementation problem
+    #[error("protocol handle abnormally closed, session id: `{0:?}`")]
     AbnormallyClosed(Option<SessionId>),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Detail error kind when dial remote error
 pub enum DialerErrorKind {
     /// IO error
-    IoError(std::io::Error),
+    #[error("dialler io error: `{0:?}`")]
+    IoError(IOError),
     /// When dial remote, peer id does not match
+    #[error("peer id not match")]
     PeerIdNotMatch,
     /// Connected to the connected peer
+    #[error("repeated connection, sessio id: `{0:?}`")]
     RepeatedConnection(SessionId),
     /// Handshake error
+    #[error("handshake error: `{0:?}`")]
     HandshakeError(HandshakeErrorKind),
     /// Transport error
+    #[error("transport error: `{0:?}`")]
     TransportError(TransportErrorKind),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Handshake error
 pub enum HandshakeErrorKind {
     /// Handshake timeout error
+    #[error("timeout error: `{0:?}`")]
     Timeout(String),
     /// Secio error
+    #[error("secio error: `{0:?}`")]
     SecioError(SecioError),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Listener error kind when dial remote error
 pub enum ListenErrorKind {
     /// IO error
-    IoError(std::io::Error),
+    #[error("listen io error: `{0:?}`")]
+    IoError(IOError),
     /// Connected to the connected peer
+    #[error("repeated connection, sessio id: `{0:?}`")]
     RepeatedConnection(SessionId),
     /// Transport error
+    #[error("transport error: `{0:?}`")]
     TransportError(TransportErrorKind),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Send error kind when send service task
 pub enum SendErrorKind {
     /// Sending failed because a pipe was closed.
+    #[error("broken pipe")]
     BrokenPipe,
     /// The operation needs to block to complete, but the blocking operation was requested to not occur.
+    #[error("would block")]
     WouldBlock,
 }

--- a/src/protocol_handle_stream.rs
+++ b/src/protocol_handle_stream.rs
@@ -13,7 +13,7 @@ use std::{
 
 use crate::{
     context::{ProtocolContext, ServiceContext, SessionContext},
-    error::Error,
+    error::ProtocolHandleErrorKind,
     multiaddr::Multiaddr,
     service::{config::BlockingFlag, future_task::BoxedFutureTask},
     session::SessionEvent,
@@ -250,11 +250,11 @@ impl<T> Drop for ServiceProtocolStream<T> {
                 let proto_id = self.handle_context.proto_id;
                 let event = match session_id {
                     Some(id) => SessionEvent::ProtocolHandleError {
-                        error: Error::ProtoHandleAbnormallyClosed(Some(id)),
+                        error: ProtocolHandleErrorKind::AbnormallyClosed(Some(id)),
                         proto_id,
                     },
                     None => SessionEvent::ProtocolHandleError {
-                        error: Error::ProtoHandleAbnormallyClosed(None),
+                        error: ProtocolHandleErrorKind::AbnormallyClosed(None),
                         proto_id,
                     },
                 };
@@ -500,7 +500,7 @@ impl<T> Drop for SessionProtocolStream<T> {
     fn drop(&mut self) {
         if !self.shutdown.load(Ordering::SeqCst) && self.current_task {
             let event = SessionEvent::ProtocolHandleError {
-                error: Error::ProtoHandleAbnormallyClosed(Some(self.context.id)),
+                error: ProtocolHandleErrorKind::AbnormallyClosed(Some(self.context.id)),
                 proto_id: self.handle_context.proto_id,
             };
             let mut panic_sender = self.panic_report.clone();

--- a/src/service/event.rs
+++ b/src/service/event.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::{
     context::SessionContext,
-    error::Error,
+    error::{DialerErrorKind, ListenErrorKind, ProtocolHandleErrorKind},
     multiaddr::Multiaddr,
     service::{future_task::BoxedFutureTask, TargetProtocol, TargetSession},
     ProtocolId, SessionId,
@@ -19,14 +19,14 @@ pub enum ServiceError {
         /// Remote address
         address: Multiaddr,
         /// error
-        error: Error,
+        error: DialerErrorKind,
     },
     /// When listen error
     ListenError {
         /// Listen address
         address: Multiaddr,
         /// error
-        error: Error,
+        error: ListenErrorKind,
     },
     /// Protocol select fail
     ProtocolSelectError {
@@ -43,7 +43,7 @@ pub enum ServiceError {
         /// Protocol id
         proto_id: ProtocolId,
         /// Codec error
-        error: Error,
+        error: std::io::Error,
     },
     /// After initializing the connection, the session does not open any protocol,
     /// suspected fd attack
@@ -56,14 +56,14 @@ pub enum ServiceError {
         /// Session context
         session_context: Arc<SessionContext>,
         /// error, such as `InvalidData`
-        error: Error,
+        error: std::io::Error,
     },
     /// Protocol handle error, will cause memory leaks/abnormal CPU usage
     ProtocolHandleError {
-        /// Error message
-        error: Error,
         /// Protocol id
         proto_id: ProtocolId,
+        /// error
+        error: ProtocolHandleErrorKind,
     },
     /// Session blocked, can't send message, may blocking global system,
     /// If the task is too heavy in a short time, it may be repeated multiple times.

--- a/src/substream.rs
+++ b/src/substream.rs
@@ -16,7 +16,6 @@ use tokio_util::codec::{length_delimited::LengthDelimitedCodec, Framed};
 use crate::{
     builder::BeforeReceive,
     context::SessionContext,
-    error::Error,
     protocol_handle_stream::{ServiceProtocolEvent, SessionProtocolEvent},
     service::{config::SessionConfig, event::Priority, DELAY_TIME},
     traits::Codec,
@@ -64,7 +63,7 @@ pub(crate) enum ProtocolEvent {
         /// Protocol id
         proto_id: ProtocolId,
         /// Codec error
-        error: Error,
+        error: std::io::Error,
     },
     TimeoutCheck,
 }
@@ -275,7 +274,7 @@ where
         self.read_buf.push_back(ProtocolEvent::Error {
             id: self.id,
             proto_id: self.proto_id,
-            error: error.into(),
+            error,
         });
         self.close_proto_stream(cx);
     }
@@ -300,7 +299,7 @@ where
                         ProtocolEvent::Error {
                             id: self.id,
                             proto_id: self.proto_id,
-                            error: err.into(),
+                            error: err,
                         },
                     );
                     self.dead = true;

--- a/tests/test_peer_id.rs
+++ b/tests/test_peer_id.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, sync::mpsc::channel, thread};
 use tentacle::{
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ServiceContext},
-    error::Error,
+    error::DialerErrorKind,
     multiaddr::Multiaddr,
     multiaddr::Protocol as MultiProtocol,
     secio::SecioKeyPair,
@@ -40,7 +40,13 @@ impl ServiceHandle for EmptySHandle {
         self.error_count += 1;
 
         if let ServiceError::DialerError { error, .. } = error {
-            assert_eq!(error, Error::PeerIdNotMatch);
+            match error {
+                DialerErrorKind::PeerIdNotMatch => {}
+                err => panic!(
+                    "test fail, expected DialerErrorKind::PeerIdNotMatch, got {:?}",
+                    err
+                ),
+            }
         } else {
             panic!("test fail {:?}", error);
         }


### PR DESCRIPTION
A big `Error` enum is used in previous code, which introduces difficulties in error handling for lib user: he need to know that only some of the error enum variables will need to be dealt with under different circumstances: for example, `ServiceError::ProtocolHandleError` only contains `ProtoHandleAbnormallyClosed` and `ProtoHandleBlock` .

This PR split it to serval small `ErrorKind` enums and refactored some internal code to use a smaller scoped error.