### PR TITLE
feat: parse slice to pubkey

### DIFF
--- a/secio/README.md
+++ b/secio/README.md
@@ -1,3 +1,5 @@
 ## Secio
 
 Encrypted communication protocol library, reference [Go](https://github.com/libp2p/go-libp2p-secio)/[Rust](https://github.com/libp2p/rust-libp2p/tree/master/protocols/secio)
+
+Use aead encryption by default


### PR DESCRIPTION
If we want to get the peerid information through the public key, the current API cannot complete this task