### PR TITLE
Split listener

### DIFF
--- a/secio/src/codec/secure_stream.rs
+++ b/secio/src/codec/secure_stream.rs
@@ -552,17 +552,7 @@ mod tests {
             );
             let mut handle = secure.create_handle().unwrap();
 
-            tokio::spawn(async move {
-                loop {
-                    match secure.next().await {
-                        Some(Err(_)) => {
-                            break;
-                        }
-                        None => break,
-                        _ => (),
-                    }
-                }
-            });
+            tokio::spawn(secure.for_each(|_| futures::future::ready(())));
 
             let _res = handle.write_all(&nonce).await;
             let _res = handle.write_all(&data_clone[..]).await;

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,9 +1,12 @@
-use futures::{channel::mpsc, prelude::*, stream::FusedStream};
+use futures::{
+    channel::mpsc,
+    prelude::*,
+    stream::{FusedStream, StreamExt},
+};
 use log::{debug, error, trace};
 use std::{
     borrow::Cow,
     collections::{vec_deque::VecDeque, HashMap, HashSet},
-    io,
     pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -16,27 +19,25 @@ use tokio::prelude::{AsyncRead, AsyncWrite};
 
 use crate::{
     context::{ServiceContext, SessionContext, SessionController},
-    error::{
-        DialerErrorKind, HandshakeErrorKind, ListenErrorKind, ProtocolHandleErrorKind,
-        TransportErrorKind,
-    },
+    error::{DialerErrorKind, ListenErrorKind, ProtocolHandleErrorKind, TransportErrorKind},
     multiaddr::{Multiaddr, Protocol},
     protocol_handle_stream::{
         ServiceProtocolEvent, ServiceProtocolStream, SessionProtocolEvent, SessionProtocolStream,
     },
     protocol_select::ProtocolInfo,
-    secio::{handshake::Config, PublicKey, SecioKeyPair},
+    secio::{PublicKey, SecioKeyPair},
     service::{
         config::{ServiceConfig, State},
         event::{Priority, ServiceTask},
         future_task::{BoxedFutureTask, FutureTaskManager},
+        helper::{HandshakeContext, Listener, Source},
     },
     session::{Session, SessionEvent, SessionMeta},
     traits::ServiceHandle,
     transports::{MultiIncoming, MultiTransport, Transport},
     upnp::IGDClient,
     utils::extract_peer_id,
-    yamux::{session::SessionType as YamuxType, Config as YamuxConfig},
+    yamux::Config as YamuxConfig,
     ProtocolId, SessionId,
 };
 
@@ -44,11 +45,13 @@ pub(crate) mod config;
 mod control;
 pub(crate) mod event;
 pub(crate) mod future_task;
+mod helper;
 
 pub use crate::service::{
     config::{BlockingFlag, ProtocolHandle, ProtocolMeta, TargetProtocol, TargetSession},
     control::ServiceControl,
     event::{ProtocolEvent, ServiceError, ServiceEvent},
+    helper::SessionType,
 };
 use bytes::Bytes;
 
@@ -80,7 +83,7 @@ pub struct Service<T> {
 
     multi_transport: MultiTransport,
 
-    listens: Vec<(Multiaddr, MultiIncoming)>,
+    listens: HashSet<Multiaddr>,
 
     igd_client: Option<IGDClient>,
 
@@ -181,7 +184,7 @@ where
             session_service_protos: HashMap::default(),
             service_proto_handles: HashMap::default(),
             session_proto_handles: HashMap::default(),
-            listens: Vec::new(),
+            listens: HashSet::new(),
             igd_client,
             dial_protocols: HashMap::default(),
             state: State::new(forever),
@@ -255,12 +258,35 @@ where
                 if let Some(client) = self.igd_client.as_mut() {
                     client.register(&listen_address)
                 }
-                self.listens.push((listen_address.clone(), value.1));
+                self.listens.insert(listen_address.clone());
 
-                Ok(listen_address)
+                self.spawn_listener(value.1, listen_address);
+
+                Ok(value.0)
             }
             Err(err) => Err(err),
         }
+    }
+
+    fn spawn_listener(&mut self, incoming: MultiIncoming, listen_address: Multiaddr) {
+        let listener = Listener {
+            inner: incoming,
+            key_pair: self.service_context.key_pair().cloned(),
+            event_sender: self.session_event_sender.clone(),
+            max_frame_length: self.config.max_frame_length,
+            timeout: self.config.timeout,
+            listen_addr: listen_address,
+            future_task_sender: self.future_task_sender.clone(),
+        };
+        let mut sender = self.future_task_sender.clone();
+        tokio::spawn(async move {
+            let res = sender
+                .send(Box::pin(listener.for_each(|_| future::ready(()))))
+                .await;
+            if res.is_err() {
+                trace!("spawn listener fail")
+            }
+        });
     }
 
     /// Use by inner
@@ -292,13 +318,7 @@ where
 
         match dial_future.await {
             Ok(value) => {
-                self.session_event_sender
-                    .send(SessionEvent::DialStart {
-                        remote_address: value.0,
-                        stream: value.1,
-                    })
-                    .await
-                    .map_err(|_| TransportErrorKind::Io(io::ErrorKind::BrokenPipe.into()))?;
+                self.handshake(value.1, SessionType::Outbound, value.0, None);
                 self.dial_protocols.insert(address, target);
                 self.state.increase();
                 Ok(self)
@@ -313,21 +333,37 @@ where
         self.dial_protocols.insert(address.clone(), target);
         let dial_future = self.multi_transport.dial(address.clone())?;
 
+        let key_pair = self.service_context.key_pair().cloned();
+        let timeout = self.config.timeout;
+        let max_frame_length = self.config.max_frame_length;
+
         let mut sender = self.session_event_sender.clone();
         let task = async move {
             let result = dial_future.await;
 
-            let event = match result {
-                Ok(value) => SessionEvent::DialStart {
-                    remote_address: value.0,
-                    stream: value.1,
-                },
-                Err(error) => SessionEvent::DialError { address, error },
+            match result {
+                Ok(value) => {
+                    HandshakeContext {
+                        ty: SessionType::Outbound,
+                        remote_address: value.0,
+                        listen_address: None,
+                        key_pair,
+                        event_sender: sender,
+                        max_frame_length,
+                        timeout,
+                    }
+                    .handshake(value.1)
+                    .await;
+                }
+                Err(error) => {
+                    if let Err(err) = sender
+                        .send(SessionEvent::DialError { address, error })
+                        .await
+                    {
+                        error!("dial address result send back error: {:?}", err);
+                    }
+                }
             };
-
-            if let Err(err) = sender.send(event).await {
-                error!("dial address result send back error: {:?}", err);
-            }
         };
 
         self.pending_tasks.push_back(Box::pin(task));
@@ -554,7 +590,7 @@ where
                     let (sender, receiver) = mpsc::channel(RECEIVED_SIZE);
                     self.session_proto_handles.insert((id, *proto_id), sender);
 
-                    let mut stream = SessionProtocolStream::new(
+                    let stream = SessionProtocolStream::new(
                         handle,
                         self.service_context.clone_self(),
                         Arc::clone(&session_control.inner),
@@ -565,18 +601,7 @@ where
                     );
                     let (sender, receiver) = futures::channel::oneshot::channel();
                     let handle = tokio::spawn(async move {
-                        future::select(
-                            async move {
-                                loop {
-                                    if stream.next().await.is_none() {
-                                        break;
-                                    }
-                                }
-                            }
-                            .boxed(),
-                            receiver,
-                        )
-                        .await;
+                        future::select(stream.for_each(|_| future::ready(())), receiver).await;
                     });
                     self.session_wait_handle
                         .insert((id, *proto_id), (Some(sender), handle));
@@ -673,7 +698,6 @@ where
     #[inline]
     fn handshake<H>(
         &mut self,
-        cx: &mut Context,
         socket: H,
         ty: SessionType,
         remote_address: Multiaddr,
@@ -681,74 +705,28 @@ where
     ) where
         H: AsyncRead + AsyncWrite + Send + 'static + Unpin,
     {
-        if let Some(key_pair) = self.service_context.key_pair() {
-            let key_pair = key_pair.clone();
-            let mut sender = self.session_event_sender.clone();
-            let max_frame_length = self.config.max_frame_length;
-            let timeout = self.config.timeout;
-
-            let handshake_task = async move {
-                let result = tokio::time::timeout(
-                    timeout,
-                    Config::new(key_pair)
-                        .max_frame_length(max_frame_length)
-                        .handshake(socket),
-                )
-                .await;
-
-                let event = match result {
-                    Err(error) => {
-                        debug!(
-                            "Handshake with {} failed, error: {:?}",
-                            remote_address, error
-                        );
-                        // time out error
-                        SessionEvent::HandshakeError {
-                            ty,
-                            error: HandshakeErrorKind::Timeout(error.to_string()),
-                            address: remote_address,
-                        }
-                    }
-                    Ok(res) => match res {
-                        Ok((handle, public_key, _)) => SessionEvent::HandshakeSuccess {
-                            handle,
-                            public_key,
-                            address: remote_address,
-                            ty,
-                            listen_address,
-                        },
-                        Err(error) => {
-                            debug!(
-                                "Handshake with {} failed, error: {:?}",
-                                remote_address, error
-                            );
-                            SessionEvent::HandshakeError {
-                                ty,
-                                error: HandshakeErrorKind::SecioError(error),
-                                address: remote_address,
-                            }
-                        }
-                    },
-                };
-                if let Err(err) = sender.send(event).await {
-                    error!("handshake result send back error: {:?}", err);
-                }
-            };
-
-            let mut future_task_sender = self.future_task_sender.clone();
-
-            tokio::spawn(async move {
-                if future_task_sender
-                    .send(Box::pin(handshake_task))
-                    .await
-                    .is_err()
-                {
-                    trace!("handshake send err")
-                }
-            });
-        } else {
-            self.session_open(cx, socket, None, remote_address, ty, listen_address);
+        let handshake_task = HandshakeContext {
+            ty,
+            remote_address,
+            listen_address,
+            key_pair: self.service_context.key_pair().cloned(),
+            event_sender: self.session_event_sender.clone(),
+            max_frame_length: self.config.max_frame_length,
+            timeout: self.config.timeout,
         }
+        .handshake(socket);
+
+        let mut future_task_sender = self.future_task_sender.clone();
+
+        tokio::spawn(async move {
+            if future_task_sender
+                .send(Box::pin(handshake_task))
+                .await
+                .is_err()
+            {
+                trace!("handshake send err")
+            }
+        });
     }
 
     fn generate_next_session(&mut self) {
@@ -773,9 +751,6 @@ where
     ) where
         H: AsyncRead + AsyncWrite + Send + 'static + Unpin,
     {
-        if ty.is_outbound() {
-            self.state.decrease();
-        }
         let target = self
             .dial_protocols
             .remove(&address)
@@ -917,13 +892,7 @@ where
             }
         }
 
-        tokio::spawn(async move {
-            loop {
-                if session.next().await.is_none() {
-                    break;
-                }
-            }
-        });
+        tokio::spawn(session.for_each(|_| future::ready(())));
 
         self.handle.handle_event(
             &mut self.service_context,
@@ -1131,27 +1100,6 @@ where
         self.send_pending_task(cx);
     }
 
-    /// check queue if full
-    fn notify_queue(&mut self, cx: &mut Context) {
-        let waker = cx.waker().clone();
-        let quick_count = self.service_context.control().quick_count.clone();
-        let normal_count = self.service_context.control().normal_count.clone();
-        let task = async move {
-            let mut interval =
-                tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_millis(200));
-            loop {
-                let waker = waker.clone();
-                interval.tick().await;
-                if quick_count.load(Ordering::SeqCst) > RECEIVED_BUFFER_SIZE / 4
-                    || normal_count.load(Ordering::SeqCst) > RECEIVED_BUFFER_SIZE / 2
-                {
-                    waker.wake();
-                }
-            }
-        };
-        self.send_future_task(cx, Box::pin(task))
-    }
-
     fn init_proto_handles(&mut self) {
         for (proto_id, meta) in self.protocol_configs.iter_mut() {
             if let ProtocolHandle::Callback(handle) | ProtocolHandle::Both(handle) =
@@ -1172,18 +1120,7 @@ where
                 stream.handle_event(ServiceProtocolEvent::Init);
                 let (sender, receiver) = futures::channel::oneshot::channel();
                 let handle = tokio::spawn(async move {
-                    future::select(
-                        async move {
-                            loop {
-                                if stream.next().await.is_none() {
-                                    break;
-                                }
-                            }
-                        }
-                        .boxed(),
-                        receiver,
-                    )
-                    .await;
+                    future::select(stream.for_each(|_| future::ready(())), receiver).await;
                 });
                 self.wait_handle.push((Some(sender), handle));
             } else {
@@ -1197,15 +1134,14 @@ where
 
     /// When listen update, call here
     #[inline]
-    fn update_listens(&mut self, cx: &mut Context) {
+    fn try_update_listens(&mut self, cx: &mut Context) {
+        if let Some(client) = self.igd_client.as_mut() {
+            client.process_only_leases_support()
+        }
         if self.listens.len() == self.service_context.listens().len() {
             return;
         }
-        let new_listens = self
-            .listens
-            .iter()
-            .map(|(address, _)| address.clone())
-            .collect::<Vec<Multiaddr>>();
+        let new_listens = self.listens.iter().cloned().collect::<Vec<Multiaddr>>();
         self.service_context.update_listens(new_listens.clone());
 
         for proto_id in self.service_proto_handles.keys() {
@@ -1242,7 +1178,22 @@ where
                 ty,
                 listen_address,
             } => {
-                self.session_open(cx, handle, Some(public_key), address, ty, listen_address);
+                if ty.is_outbound() {
+                    self.state.decrease();
+                }
+                let is_continue = self
+                    .listens
+                    .len()
+                    .checked_add(self.sessions.len())
+                    .and_then(|count| {
+                        count.checked_add(self.state.into_inner().unwrap_or_default())
+                    })
+                    .map(|count| self.config.max_connection_number >= count)
+                    .unwrap_or_default();
+                if !is_continue {
+                    return;
+                }
+                self.session_open(cx, handle, public_key, address, ty, listen_address);
             }
             SessionEvent::HandshakeError { ty, error, address } => {
                 if ty.is_outbound() {
@@ -1304,14 +1255,26 @@ where
                 )
             }
             SessionEvent::ListenError { address, error } => {
-                self.state.decrease();
                 self.handle.handle_error(
                     &mut self.service_context,
                     ServiceError::ListenError {
-                        address,
+                        address: address.clone(),
                         error: ListenErrorKind::TransportError(error),
                     },
-                )
+                );
+                if self.listens.remove(&address) {
+                    if let Some(ref mut client) = self.igd_client {
+                        client.remove(&address);
+                    }
+
+                    self.handle.handle_event(
+                        &mut self.service_context,
+                        ServiceEvent::ListenClose { address },
+                    )
+                } else {
+                    // try start listen error
+                    self.state.decrease();
+                }
             }
             SessionEvent::SessionTimeout { id } => {
                 if let Some(session_control) = self.sessions.get(&id) {
@@ -1344,18 +1307,14 @@ where
                         address: listen_address.clone(),
                     },
                 );
+                self.listens.insert(listen_address.clone());
+                self.state.decrease();
+                self.try_update_listens(cx);
                 if let Some(client) = self.igd_client.as_mut() {
                     client.register(&listen_address)
                 }
-                self.listens.push((listen_address, incoming));
-                self.state.decrease();
-                self.update_listens(cx);
-                self.listen_poll(cx);
+                self.spawn_listener(incoming, listen_address);
             }
-            SessionEvent::DialStart {
-                remote_address,
-                stream,
-            } => self.handshake(cx, stream, SessionType::Outbound, remote_address, None),
             SessionEvent::ProtocolHandleError { error, proto_id } => {
                 self.handle.handle_error(
                     &mut self.service_context,
@@ -1392,7 +1351,7 @@ where
                 }
             }
             ServiceTask::Listen { address } => {
-                if !self.listens.iter().any(|(addr, _)| addr == &address) {
+                if !self.listens.contains(&address) {
                     if let Err(e) = self.listen_inner(address.clone()) {
                         self.handle.handle_error(
                             &mut self.service_context,
@@ -1491,8 +1450,7 @@ where
             ServiceTask::Shutdown(quick) => {
                 self.state.pre_shutdown();
 
-                while let Some((address, incoming)) = self.listens.pop() {
-                    drop(incoming);
+                for address in self.listens.drain() {
                     self.handle.handle_event(
                         &mut self.service_context,
                         ServiceEvent::ListenClose { address },
@@ -1527,74 +1485,6 @@ where
                         .for_each(|i| self.session_close(cx, i, Source::External));
                 }
             }
-        }
-    }
-
-    /// Poll listen connections
-    #[inline]
-    fn listen_poll(&mut self, cx: &mut Context) {
-        if !self
-            .listens
-            .len()
-            .checked_add(self.sessions.len())
-            .and_then(|count| count.checked_add(self.state.into_inner().unwrap_or_default()))
-            .map(|count| self.config.max_connection_number >= count)
-            .unwrap_or_default()
-        {
-            return;
-        }
-        let mut update = false;
-        for (address, mut listen) in self.listens.split_off(0) {
-            match Pin::new(&mut listen).as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok((remote_address, socket)))) => {
-                    self.handshake(
-                        cx,
-                        socket,
-                        SessionType::Inbound,
-                        remote_address,
-                        Some(address.clone()),
-                    );
-                    self.listens.push((address, listen));
-                }
-                Poll::Ready(None) => {
-                    update = true;
-                    if let Some(client) = self.igd_client.as_mut() {
-                        client.remove(&address)
-                    }
-                    self.handle.handle_event(
-                        &mut self.service_context,
-                        ServiceEvent::ListenClose { address },
-                    );
-                }
-                Poll::Pending => {
-                    self.listens.push((address, listen));
-                }
-                Poll::Ready(Some(Err(err))) => {
-                    update = true;
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ListenError {
-                            address: address.clone(),
-                            error: ListenErrorKind::IoError(err),
-                        },
-                    );
-                    if let Some(client) = self.igd_client.as_mut() {
-                        client.remove(&address)
-                    }
-                    self.handle.handle_event(
-                        &mut self.service_context,
-                        ServiceEvent::ListenClose { address },
-                    );
-                }
-            }
-        }
-
-        if update || self.service_context.listens().is_empty() {
-            self.update_listens(cx)
-        }
-
-        if let Some(client) = self.igd_client.as_mut() {
-            client.process_only_leases_support()
         }
     }
 
@@ -1682,8 +1572,8 @@ where
         // However, if you are on a single-core bully machine, `notify` may have a very amazing starvation behavior.
         //
         // Under a single-core machine, `notify` may fall into the loop of infinitely preemptive CPU, causing starvation.
-        if !self.delay.load(Ordering::SeqCst) {
-            self.delay.store(true, Ordering::SeqCst);
+        if !self.delay.load(Ordering::Acquire) {
+            self.delay.store(true, Ordering::Release);
             let waker = cx.waker().clone();
             let delay = self.delay.clone();
             tokio::spawn(async move {
@@ -1746,24 +1636,12 @@ where
             return self.wait_handle_poll(cx);
         }
 
-        if let Some(mut stream) = self.future_task_manager.take() {
+        if let Some(stream) = self.future_task_manager.take() {
             let (sender, receiver) = futures::channel::oneshot::channel();
             let handle = tokio::spawn(async move {
-                future::select(
-                    async move {
-                        loop {
-                            if stream.next().await.is_none() {
-                                break;
-                            }
-                        }
-                    }
-                    .boxed(),
-                    receiver,
-                )
-                .await;
+                future::select(stream.for_each(|_| future::ready(())), receiver).await;
             });
             self.wait_handle.push((Some(sender), handle));
-            self.notify_queue(cx);
             self.init_proto_handles();
         }
 
@@ -1774,7 +1652,7 @@ where
             self.distribute_to_user_level(cx);
         }
 
-        self.listen_poll(cx);
+        self.try_update_listens(cx);
 
         self.session_poll(cx);
 
@@ -1796,7 +1674,7 @@ where
         }
 
         debug!(
-            "> listens count: {}, state: {:?}, sessions count: {}, \
+            "listens count: {}, state: {:?}, sessions count: {}, \
              pending task: {}, normal_count: {}, quick_count: {}, high_write_buf: {}, write_buf: {}, read_service_buf: {}, read_session_buf: {}",
             self.listens.len(),
             self.state,
@@ -1817,59 +1695,5 @@ where
         );
 
         Poll::Pending
-    }
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum Source {
-    /// Event from user
-    External,
-    /// Event from session
-    Internal,
-}
-
-/// Indicates the session type
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum SessionType {
-    /// Representing yourself as the active party means that you are the client side
-    Outbound,
-    /// Representing yourself as a passive recipient means that you are the server side
-    Inbound,
-}
-
-impl SessionType {
-    /// is outbound
-    #[inline]
-    pub fn is_outbound(self) -> bool {
-        match self {
-            SessionType::Outbound => true,
-            SessionType::Inbound => false,
-        }
-    }
-
-    /// is inbound
-    #[inline]
-    pub fn is_inbound(self) -> bool {
-        !self.is_outbound()
-    }
-}
-
-impl From<YamuxType> for SessionType {
-    #[inline]
-    fn from(ty: YamuxType) -> Self {
-        match ty {
-            YamuxType::Client => SessionType::Outbound,
-            YamuxType::Server => SessionType::Inbound,
-        }
-    }
-}
-
-impl Into<YamuxType> for SessionType {
-    #[inline]
-    fn into(self) -> YamuxType {
-        match self {
-            SessionType::Outbound => YamuxType::Client,
-            SessionType::Inbound => YamuxType::Server,
-        }
     }
 }

--- a/src/service/helper.rs
+++ b/src/service/helper.rs
@@ -1,0 +1,236 @@
+use futures::{channel::mpsc, prelude::*};
+use log::{debug, error, trace};
+use multiaddr::Multiaddr;
+use secio::handshake::Config;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::prelude::{AsyncRead, AsyncWrite};
+use yamux::session::SessionType as YamuxType;
+
+use crate::{
+    error::{HandshakeErrorKind, TransportErrorKind},
+    service::future_task::BoxedFutureTask,
+    session::SessionEvent,
+    transports::MultiIncoming,
+};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Source {
+    /// Event from user
+    External,
+    /// Event from session
+    Internal,
+}
+
+/// Indicates the session type
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum SessionType {
+    /// Representing yourself as the active party means that you are the client side
+    Outbound,
+    /// Representing yourself as a passive recipient means that you are the server side
+    Inbound,
+}
+
+impl SessionType {
+    /// is outbound
+    #[inline]
+    pub fn is_outbound(self) -> bool {
+        match self {
+            SessionType::Outbound => true,
+            SessionType::Inbound => false,
+        }
+    }
+
+    /// is inbound
+    #[inline]
+    pub fn is_inbound(self) -> bool {
+        !self.is_outbound()
+    }
+}
+
+impl From<YamuxType> for SessionType {
+    #[inline]
+    fn from(ty: YamuxType) -> Self {
+        match ty {
+            YamuxType::Client => SessionType::Outbound,
+            YamuxType::Server => SessionType::Inbound,
+        }
+    }
+}
+
+impl Into<YamuxType> for SessionType {
+    #[inline]
+    fn into(self) -> YamuxType {
+        match self {
+            SessionType::Outbound => YamuxType::Client,
+            SessionType::Inbound => YamuxType::Server,
+        }
+    }
+}
+
+pub(crate) struct HandshakeContext {
+    pub(crate) key_pair: Option<secio::SecioKeyPair>,
+    pub(crate) event_sender: mpsc::Sender<SessionEvent>,
+    pub(crate) max_frame_length: usize,
+    pub(crate) timeout: Duration,
+    pub(crate) ty: SessionType,
+    pub(crate) remote_address: Multiaddr,
+    pub(crate) listen_address: Option<Multiaddr>,
+}
+
+impl HandshakeContext {
+    pub async fn handshake<H>(mut self, socket: H)
+    where
+        H: AsyncRead + AsyncWrite + Send + 'static + Unpin,
+    {
+        match self.key_pair {
+            Some(key_pair) => {
+                let result = tokio::time::timeout(
+                    self.timeout,
+                    Config::new(key_pair)
+                        .max_frame_length(self.max_frame_length)
+                        .handshake(socket),
+                )
+                .await;
+
+                let event = match result {
+                    Err(error) => {
+                        debug!(
+                            "Handshake with {} failed, error: {:?}",
+                            self.remote_address, error
+                        );
+                        // time out error
+                        SessionEvent::HandshakeError {
+                            ty: self.ty,
+                            error: HandshakeErrorKind::Timeout(error.to_string()),
+                            address: self.remote_address,
+                        }
+                    }
+                    Ok(res) => match res {
+                        Ok((handle, public_key, _)) => SessionEvent::HandshakeSuccess {
+                            handle: Box::new(handle),
+                            public_key: Some(public_key),
+                            address: self.remote_address,
+                            ty: self.ty,
+                            listen_address: self.listen_address,
+                        },
+                        Err(error) => {
+                            debug!(
+                                "Handshake with {} failed, error: {:?}",
+                                self.remote_address, error
+                            );
+                            SessionEvent::HandshakeError {
+                                ty: self.ty,
+                                error: HandshakeErrorKind::SecioError(error),
+                                address: self.remote_address,
+                            }
+                        }
+                    },
+                };
+                if let Err(err) = self.event_sender.send(event).await {
+                    error!("handshake result send back error: {:?}", err);
+                }
+            }
+            None => {
+                let event = SessionEvent::HandshakeSuccess {
+                    handle: Box::new(socket),
+                    public_key: None,
+                    address: self.remote_address,
+                    ty: self.ty,
+                    listen_address: self.listen_address,
+                };
+                if let Err(err) = self.event_sender.send(event).await {
+                    error!("handshake result send back error: {:?}", err);
+                }
+            }
+        }
+    }
+}
+
+pub struct Listener {
+    pub(crate) inner: MultiIncoming,
+    pub(crate) key_pair: Option<secio::SecioKeyPair>,
+    pub(crate) event_sender: mpsc::Sender<SessionEvent>,
+    pub(crate) max_frame_length: usize,
+    pub(crate) timeout: Duration,
+    pub(crate) listen_addr: Multiaddr,
+    pub(crate) future_task_sender: mpsc::Sender<BoxedFutureTask>,
+}
+
+impl Listener {
+    fn close(&self, io_err: io::Error) {
+        let mut event_sender = self.event_sender.clone();
+        let mut future_sender = self.future_task_sender.clone();
+        let address = self.listen_addr.clone();
+        let report_task = async move {
+            if let Err(err) = event_sender
+                .send(SessionEvent::ListenError {
+                    address,
+                    error: TransportErrorKind::Io(io_err),
+                })
+                .await
+            {
+                error!("Listen address result send back error: {:?}", err);
+            }
+        };
+        tokio::spawn(async move {
+            if future_sender.send(Box::pin(report_task)).await.is_err() {
+                trace!("Listen address result send to future manager error");
+            }
+        });
+    }
+
+    fn handshake<H>(&self, socket: H, remote_address: Multiaddr)
+    where
+        H: AsyncRead + AsyncWrite + Send + 'static + Unpin,
+    {
+        let handshake_task = HandshakeContext {
+            ty: SessionType::Inbound,
+            remote_address,
+            listen_address: Some(self.listen_addr.clone()),
+            key_pair: self.key_pair.clone(),
+            event_sender: self.event_sender.clone(),
+            max_frame_length: self.max_frame_length,
+            timeout: self.timeout,
+        }
+        .handshake(socket);
+
+        let mut future_task_sender = self.future_task_sender.clone();
+
+        tokio::spawn(async move {
+            if future_task_sender
+                .send(Box::pin(handshake_task))
+                .await
+                .is_err()
+            {
+                trace!("handshake send err")
+            }
+        });
+    }
+}
+
+impl Stream for Listener {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok((remote_address, socket)))) => {
+                self.handshake(socket, remote_address);
+                Poll::Ready(Some(()))
+            }
+            Poll::Ready(None) => {
+                self.close(io::ErrorKind::BrokenPipe.into());
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Err(err))) => {
+                self.close(err);
+                Poll::Ready(None)
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Split listener from Service
2. Use `foreach` instead of `boxed` to reduce box cost
3. Unified handshake success event stream to `Dyn trait`
4. Remove `dialstart` event, it can directly enter the handshake process and does not require one more communication
5. Unified handshake process as a single abstraction

This pr depends on the previous pr and  #237 needs to be reviewed first