### PR TITLE
feat: Remove sevice's awareness of protocol

### DIFF
--- a/tests/test_block_future_task.rs
+++ b/tests/test_block_future_task.rs
@@ -27,7 +27,7 @@ impl ServiceProtocol for PHandle {
     fn init(&mut self, context: &mut ProtocolContext) {
         let proto_id = context.proto_id;
 
-        let _rse = context.set_service_notify(proto_id, Duration::from_secs(1), 1);
+        let _rse = context.set_service_notify(proto_id, Duration::from_millis(100), 1);
 
         for _ in 0..4096 {
             let _res = context.future_task(pending());

--- a/tests/test_close.rs
+++ b/tests/test_close.rs
@@ -44,7 +44,7 @@ impl ServiceProtocol for PHandle {
             self.count += 1;
             if self.count >= 4 {
                 let proto_id = context.proto_id;
-                let _res = context.set_service_notify(proto_id, Duration::from_secs(2), 0);
+                let _res = context.set_service_notify(proto_id, Duration::from_millis(200), 0);
             }
         }
     }

--- a/tests/test_dial.rs
+++ b/tests/test_dial.rs
@@ -119,7 +119,7 @@ struct PHandle {
 impl ServiceProtocol for PHandle {
     fn init(&mut self, context: &mut ProtocolContext) {
         let proto_id = context.proto_id;
-        let _res = context.set_service_notify(proto_id, Duration::from_secs(1), 3);
+        let _res = context.set_service_notify(proto_id, Duration::from_millis(100), 3);
     }
 
     fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
@@ -302,7 +302,7 @@ fn test_dial_with_no_notify(secio: bool) {
             let addr = format!("/ip4/127.0.0.1/tcp/{}", i).parse().unwrap();
             control.dial(addr, TargetProtocol::All).unwrap();
         }
-        std::thread::sleep(Duration::from_secs(3));
+        std::thread::sleep(Duration::from_millis(300));
     }
     assert_eq!(
         check_dial_errors(error_receiver, Duration::from_secs(15), 10),


### PR DESCRIPTION
1. Remove the service record of protocols on and off
2. Migration of session protocol handle records to session management
3. When the Event mode is disabled, cancel the ProtocolOpen and ProtocolClose events

Review the other #237 #238  two PRs first