### PR TITLE
refacor: Rewrite buffer cache

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1654,10 +1654,14 @@ where
             self.state,
             self.sessions.len(),
             self.pending_tasks.len(),
-            self.high_write_buf.len(),
-            self.write_buf.len(),
-            self.read_service_buf.len(),
-            self.read_session_buf.len(),
+            self.high_write_buf.values()
+                .fold(0, |acc, item| acc + item.len()),
+            self.write_buf.values()
+                .fold(0, |acc, item| acc + item.len()),
+            self.read_service_buf.values()
+                .fold(0, |acc, item| acc + item.len()),
+            self.read_session_buf.values()
+                .fold(0, |acc, item| acc + item.len()),
         );
 
         if is_pending {

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,7 +3,7 @@ use futures::{
     prelude::*,
     stream::{FusedStream, StreamExt},
 };
-use log::{debug, error, trace};
+use log::{debug, error, log_enabled, trace};
 use std::{
     borrow::Cow,
     collections::{vec_deque::VecDeque, HashMap, HashSet},
@@ -1647,22 +1647,24 @@ where
             return self.wait_handle_poll(cx);
         }
 
-        debug!(
-            "listens count: {}, state: {:?}, sessions count: {}, \
+        if log_enabled!(log::Level::Debug) {
+            debug!(
+                "listens count: {}, state: {:?}, sessions count: {}, \
              pending task: {}, high_write_buf: {}, write_buf: {}, read_service_buf: {}, read_session_buf: {}",
-            self.listens.len(),
-            self.state,
-            self.sessions.len(),
-            self.pending_tasks.len(),
-            self.high_write_buf.values()
-                .fold(0, |acc, item| acc + item.len()),
-            self.write_buf.values()
-                .fold(0, |acc, item| acc + item.len()),
-            self.read_service_buf.values()
-                .fold(0, |acc, item| acc + item.len()),
-            self.read_session_buf.values()
-                .fold(0, |acc, item| acc + item.len()),
-        );
+                self.listens.len(),
+                self.state,
+                self.sessions.len(),
+                self.pending_tasks.len(),
+                self.high_write_buf.values()
+                    .fold(0, |acc, item| acc + item.len()),
+                self.write_buf.values()
+                    .fold(0, |acc, item| acc + item.len()),
+                self.read_service_buf.values()
+                    .fold(0, |acc, item| acc + item.len()),
+                self.read_session_buf.values()
+                    .fold(0, |acc, item| acc + item.len()),
+            );
+        }
 
         if is_pending {
             Poll::Pending

--- a/src/session.rs
+++ b/src/session.rs
@@ -549,6 +549,8 @@ where
                 debug!("session [{}] proto [{}] closed", self.context.id, proto_id);
                 if self.sub_streams.remove(&id).is_some() {
                     self.proto_streams.remove(&proto_id);
+                    self.high_write_buf.remove(&proto_id);
+                    self.write_buf.remove(&proto_id);
                     if self.event.contains(&proto_id) {
                         self.event_output(
                             cx,
@@ -874,8 +876,12 @@ where
             self.sub_streams.len(),
             self.state,
             self.read_buf.len(),
-            self.write_buf.len(),
-            self.high_write_buf.len()
+            self.write_buf
+                .values()
+                .fold(0, |acc, item| acc + item.len()),
+            self.high_write_buf
+                .values()
+                .fold(0, |acc, item| acc + item.len())
         );
 
         // double check here

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
 use futures::{channel::mpsc, prelude::*, stream::iter};
-use log::{debug, error, trace};
+use log::{debug, error, log_enabled, trace};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::{
     io::{self, ErrorKind},
@@ -868,21 +868,23 @@ where
     type Item = ();
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        debug!(
-            "session [{}], [{:?}], proto count [{}], state: {:?} ,\
+        if log_enabled!(log::Level::Debug) {
+            debug!(
+                "session [{}], [{:?}], proto count [{}], state: {:?} ,\
              read buf: {}, write buf: {}, high_write_buf: {}",
-            self.context.id,
-            self.context.ty,
-            self.sub_streams.len(),
-            self.state,
-            self.read_buf.len(),
-            self.write_buf
-                .values()
-                .fold(0, |acc, item| acc + item.len()),
-            self.high_write_buf
-                .values()
-                .fold(0, |acc, item| acc + item.len())
-        );
+                self.context.id,
+                self.context.ty,
+                self.sub_streams.len(),
+                self.state,
+                self.read_buf.len(),
+                self.write_buf
+                    .values()
+                    .fold(0, |acc, item| acc + item.len()),
+                self.high_write_buf
+                    .values()
+                    .fold(0, |acc, item| acc + item.len())
+            );
+        }
 
         // double check here
         if self.state.is_local_close() {

--- a/src/substream.rs
+++ b/src/substream.rs
@@ -204,7 +204,7 @@ where
                 .push_back(ServiceProtocolEvent::Disconnected {
                     id: self.context.id,
                 });
-            let events = self.service_proto_buf.split_off(0);
+            let events = ::std::mem::replace(&mut self.service_proto_buf, VecDeque::new());
             let mut sender = self.service_proto_sender.take().unwrap();
             tokio::spawn(async move {
                 let mut iter = iter(events).map(Ok);
@@ -223,7 +223,7 @@ where
                     .push_back(SessionProtocolEvent::Disconnected);
             }
 
-            let events = self.session_proto_buf.split_off(0);
+            let events = ::std::mem::replace(&mut self.session_proto_buf, VecDeque::new());
             let mut sender = self.session_proto_sender.take().unwrap();
             tokio::spawn(async move {
                 let mut iter = iter(events).map(Ok);
@@ -239,7 +239,7 @@ where
         });
 
         if !self.context.closed.load(Ordering::SeqCst) {
-            let events = self.read_buf.split_off(0);
+            let events = ::std::mem::replace(&mut self.read_buf, VecDeque::new());
             let mut sender = self.event_sender.clone();
 
             tokio::spawn(async move {

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -432,7 +432,7 @@ where
             }
         }
         for id in disconnect_streams {
-            self.read_pending_frames.remove(&id);
+            buf.remove(&id);
         }
         self.read_pending_frames = buf;
 


### PR DESCRIPTION
Considering that what we need is hierarchical ordering instead of global ordering, the original buffer strategy guarantees global ordering, and there will be additional consumption. For example, the buffers must be traversed all the time, and after changing the order to the hierarchy, this Side effects will disappear

dependence #243 