### PR TITLE
feat: Add control on yamux

### DIFF
--- a/tests/test_session_protocol_open_close.rs
+++ b/tests/test_session_protocol_open_close.rs
@@ -55,7 +55,7 @@ impl SessionProtocol for PHandle {
             // each close add one
             self.count += 1;
             if self.count >= 10 {
-                context.shutdown().unwrap();
+                let _ignore = context.shutdown();
             }
         }
     }

--- a/yamux/src/control.rs
+++ b/yamux/src/control.rs
@@ -1,0 +1,156 @@
+use futures::{
+    channel::{mpsc, oneshot},
+    sink::SinkExt,
+    FutureExt,
+};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::{error::Error, stream::StreamHandle};
+
+pub(crate) enum Command {
+    OpenStream(oneshot::Sender<Result<StreamHandle, Error>>),
+    Shutdown(oneshot::Sender<()>),
+}
+
+/// A session control is used to open the stream or close the session
+pub struct Control {
+    sender: mpsc::Sender<Command>,
+    pending_open: Option<oneshot::Receiver<Result<StreamHandle, Error>>>,
+    pending_close: Option<oneshot::Receiver<()>>,
+}
+
+impl Control {
+    pub(crate) fn new(sender: mpsc::Sender<Command>) -> Self {
+        Control {
+            sender,
+            pending_open: None,
+            pending_close: None,
+        }
+    }
+
+    /// Open a new stream to remote session
+    pub async fn open_stream(&mut self) -> Result<StreamHandle, Error> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Command::OpenStream(tx))
+            .await
+            .map_err(|_| Error::SessionShutdown)?;
+        rx.await.map_err(|_| Error::SessionShutdown)?
+    }
+
+    /// shutdown is used to close the session and all streams.
+    pub async fn close(&mut self) {
+        if self.sender.is_closed() {
+            return;
+        }
+        let (tx, rx) = oneshot::channel();
+        let _ignore = self.sender.send(Command::Shutdown(tx)).await;
+        let _ignore = rx.await;
+    }
+
+    /// Poll base open stream
+    pub fn poll_open_stream(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Result<StreamHandle, Error>> {
+        loop {
+            match self.pending_open.take() {
+                None => match self.sender.poll_ready(cx) {
+                    Poll::Ready(Ok(_)) => {
+                        let (tx, rx) = oneshot::channel();
+                        match self.sender.start_send(Command::OpenStream(tx)) {
+                            Err(err) => {
+                                if err.is_full() {
+                                    return Poll::Pending;
+                                } else {
+                                    return Poll::Ready(Err(Error::SessionShutdown));
+                                }
+                            }
+                            Ok(_) => {
+                                self.pending_open = Some(rx);
+                                continue;
+                            }
+                        }
+                    }
+                    Poll::Ready(Err(e)) => {
+                        if e.is_full() {
+                            return Poll::Pending;
+                        } else {
+                            return Poll::Ready(Err(Error::SessionShutdown));
+                        }
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                Some(mut rx) => match rx.poll_unpin(cx) {
+                    Poll::Ready(Ok(result)) => return Poll::Ready(result),
+                    Poll::Pending => {
+                        self.pending_open = Some(rx);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(_)) => {
+                        // drop return means session is gone
+                        return Poll::Ready(Err(Error::SessionShutdown));
+                    }
+                },
+            }
+        }
+    }
+
+    /// Poll base close session
+    pub fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        loop {
+            match self.pending_close.take() {
+                None => match self.sender.poll_ready(cx) {
+                    Poll::Ready(Ok(_)) => {
+                        let (tx, rx) = oneshot::channel();
+                        match self.sender.start_send(Command::Shutdown(tx)) {
+                            Ok(_) => {
+                                self.pending_close = Some(rx);
+                                continue;
+                            }
+                            Err(e) => {
+                                if e.is_full() {
+                                    return Poll::Pending;
+                                } else {
+                                    return Poll::Ready(());
+                                }
+                            }
+                        }
+                    }
+                    Poll::Ready(Err(e)) => {
+                        if e.is_full() {
+                            return Poll::Pending;
+                        } else {
+                            return Poll::Ready(());
+                        }
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                Some(mut rx) => match rx.poll_unpin(cx) {
+                    Poll::Ready(Ok(())) => return Poll::Ready(()),
+                    Poll::Ready(Err(_)) => {
+                        // drop return means session is gone
+                        return Poll::Ready(());
+                    }
+                    Poll::Pending => {
+                        self.pending_close = Some(rx);
+                        return Poll::Pending;
+                    }
+                },
+            }
+        }
+    }
+}
+
+impl Clone for Control {
+    fn clone(&self) -> Self {
+        Control {
+            sender: self.sender.clone(),
+            pending_open: None,
+            pending_close: None,
+        }
+    }
+}

--- a/yamux/src/control.rs
+++ b/yamux/src/control.rs
@@ -1,11 +1,6 @@
 use futures::{
     channel::{mpsc, oneshot},
     sink::SinkExt,
-    FutureExt,
-};
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
 };
 
 use crate::{error::Error, stream::StreamHandle};
@@ -16,25 +11,18 @@ pub(crate) enum Command {
 }
 
 /// A session control is used to open the stream or close the session
-pub struct Control {
-    sender: mpsc::Sender<Command>,
-    pending_open: Option<oneshot::Receiver<Result<StreamHandle, Error>>>,
-    pending_close: Option<oneshot::Receiver<()>>,
-}
+#[derive(Clone)]
+pub struct Control(mpsc::Sender<Command>);
 
 impl Control {
     pub(crate) fn new(sender: mpsc::Sender<Command>) -> Self {
-        Control {
-            sender,
-            pending_open: None,
-            pending_close: None,
-        }
+        Control(sender)
     }
 
     /// Open a new stream to remote session
     pub async fn open_stream(&mut self) -> Result<StreamHandle, Error> {
         let (tx, rx) = oneshot::channel();
-        self.sender
+        self.0
             .send(Command::OpenStream(tx))
             .await
             .map_err(|_| Error::SessionShutdown)?;
@@ -43,114 +31,11 @@ impl Control {
 
     /// shutdown is used to close the session and all streams.
     pub async fn close(&mut self) {
-        if self.sender.is_closed() {
+        if self.0.is_closed() {
             return;
         }
         let (tx, rx) = oneshot::channel();
-        let _ignore = self.sender.send(Command::Shutdown(tx)).await;
+        let _ignore = self.0.send(Command::Shutdown(tx)).await;
         let _ignore = rx.await;
-    }
-
-    /// Poll base open stream
-    pub fn poll_open_stream(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context,
-    ) -> Poll<Result<StreamHandle, Error>> {
-        loop {
-            match self.pending_open.take() {
-                None => match self.sender.poll_ready(cx) {
-                    Poll::Ready(Ok(_)) => {
-                        let (tx, rx) = oneshot::channel();
-                        match self.sender.start_send(Command::OpenStream(tx)) {
-                            Err(err) => {
-                                if err.is_full() {
-                                    return Poll::Pending;
-                                } else {
-                                    return Poll::Ready(Err(Error::SessionShutdown));
-                                }
-                            }
-                            Ok(_) => {
-                                self.pending_open = Some(rx);
-                                continue;
-                            }
-                        }
-                    }
-                    Poll::Ready(Err(e)) => {
-                        if e.is_full() {
-                            return Poll::Pending;
-                        } else {
-                            return Poll::Ready(Err(Error::SessionShutdown));
-                        }
-                    }
-                    Poll::Pending => return Poll::Pending,
-                },
-                Some(mut rx) => match rx.poll_unpin(cx) {
-                    Poll::Ready(Ok(result)) => return Poll::Ready(result),
-                    Poll::Pending => {
-                        self.pending_open = Some(rx);
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(Err(_)) => {
-                        // drop return means session is gone
-                        return Poll::Ready(Err(Error::SessionShutdown));
-                    }
-                },
-            }
-        }
-    }
-
-    /// Poll base close session
-    pub fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
-        loop {
-            match self.pending_close.take() {
-                None => match self.sender.poll_ready(cx) {
-                    Poll::Ready(Ok(_)) => {
-                        let (tx, rx) = oneshot::channel();
-                        match self.sender.start_send(Command::Shutdown(tx)) {
-                            Ok(_) => {
-                                self.pending_close = Some(rx);
-                                continue;
-                            }
-                            Err(e) => {
-                                if e.is_full() {
-                                    return Poll::Pending;
-                                } else {
-                                    return Poll::Ready(());
-                                }
-                            }
-                        }
-                    }
-                    Poll::Ready(Err(e)) => {
-                        if e.is_full() {
-                            return Poll::Pending;
-                        } else {
-                            return Poll::Ready(());
-                        }
-                    }
-                    Poll::Pending => return Poll::Pending,
-                },
-                Some(mut rx) => match rx.poll_unpin(cx) {
-                    Poll::Ready(Ok(())) => return Poll::Ready(()),
-                    Poll::Ready(Err(_)) => {
-                        // drop return means session is gone
-                        return Poll::Ready(());
-                    }
-                    Poll::Pending => {
-                        self.pending_close = Some(rx);
-                        return Poll::Pending;
-                    }
-                },
-            }
-        }
-    }
-}
-
-impl Clone for Control {
-    fn clone(&self) -> Self {
-        Control {
-            sender: self.sender.clone(),
-            pending_open: None,
-            pending_close: None,
-        }
     }
 }

--- a/yamux/src/lib.rs
+++ b/yamux/src/lib.rs
@@ -13,12 +13,15 @@ pub mod frame;
 // Session module
 pub mod session;
 // Stream module
+mod control;
 pub mod stream;
 
 // Stream ID type
 pub(crate) type StreamId = u32;
 
-pub use crate::{config::Config, error::Error, session::Session, stream::StreamHandle};
+pub use crate::{
+    config::Config, control::Control, error::Error, session::Session, stream::StreamHandle,
+};
 
 // Latest Protocol Version
 pub(crate) const PROTOCOL_VERSION: u8 = 0;

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -483,13 +483,14 @@ impl AsyncWrite for StreamHandle {
 impl Drop for StreamHandle {
     fn drop(&mut self) {
         if !self.event_sender.is_closed()
-            && (self.state != StreamState::Closed || self.state != StreamState::LocalClosing)
+            && self.state != StreamState::Closed
+            && self.state != StreamState::LocalClosing
         {
             let mut flags = self.get_flags();
             flags.add(Flag::Rst);
             let frame = Frame::new_window_update(flags, self.id, 0);
             let rst_event = StreamEvent::Frame(frame);
-            let event = StreamEvent::StateChanged((self.id, self.state));
+            let event = StreamEvent::StateChanged((self.id, StreamState::Closed));
             let mut sender = self.event_sender.clone();
 
             tokio::spawn(async move {

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -4,7 +4,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{
     channel::mpsc::{Receiver, Sender},
     stream::FusedStream,
-    Stream,
+    SinkExt, Stream,
 };
 
 use std::{
@@ -476,6 +476,26 @@ impl AsyncWrite for StreamHandle {
             Err(Error::WouldBlock) => Poll::Pending,
             Err(_) => Poll::Ready(Err(io::ErrorKind::BrokenPipe.into())),
             Ok(()) => Poll::Ready(Ok(())),
+        }
+    }
+}
+
+impl Drop for StreamHandle {
+    fn drop(&mut self) {
+        if !self.event_sender.is_closed()
+            && (self.state != StreamState::Closed || self.state != StreamState::LocalClosing)
+        {
+            let mut flags = self.get_flags();
+            flags.add(Flag::Rst);
+            let frame = Frame::new_window_update(flags, self.id, 0);
+            let rst_event = StreamEvent::Frame(frame);
+            let event = StreamEvent::StateChanged((self.id, self.state));
+            let mut sender = self.event_sender.clone();
+
+            tokio::spawn(async move {
+                let _ignore = sender.send(rst_event).await;
+                let _ignore = sender.send(event).await;
+            });
         }
     }
 }


### PR DESCRIPTION
The previous way `yamux` was written forced the user to wrap the session in their own upper-tier application, which was not a good experience and was a historical decision. When async was unstable, control implementations were not as practical, but now control can be abstracted out.

The upper wrapper `yamux` session affects the efficiency of upper-level data delivery, and a lot of time is taken up by the lower level sending and receiving. The better way to handle it is to spawn out.

At the same time, when the stream is unexpectedly disconnected, an RST message should be sent to the counterpart, the current implementation of the drop.

