### PR TITLE
fix: Add send go away

### DIFF
--- a/yamux/src/frame.rs
+++ b/yamux/src/frame.rs
@@ -211,7 +211,7 @@ impl Flags {
 /// When a session is being terminated, the Go Away message should
 /// be sent. The Length should be set to one of the following to
 /// provide an error code:
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum GoAwayCode {
     /// Normal termination


### PR DESCRIPTION
`yamux` has some discrepancies in exception handling that need to be fixed.

read data error： flag error or data > max length
https://github.com/hashicorp/yamux/blob/7221087c3d281fda5f794e28c2ea4c6e4d5c4558/session.go#L516
https://github.com/hashicorp/yamux/blob/7221087c3d281fda5f794e28c2ea4c6e4d5c4558/session.go#L526

open stream with an existing stream id
https://github.com/hashicorp/yamux/blob/7221087c3d281fda5f794e28c2ea4c6e4d5c4558/session.go#L600

These fixes do not have compatibility issues and reduce the tolerance for anomalous behavior

dependence #246 