### PR TITLE
feat: Rewrite buffer cache

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,248 @@
+use crate::{channel::mpsc::Sender as priotity_sender, service::BUF_SHRINK_THRESHOLD};
+use futures::channel::mpsc::Sender;
+use std::{
+    collections::VecDeque,
+    task::{Context, Poll},
+};
+
+pub enum SendResult {
+    Ok,
+    Pending,
+    Disconnect,
+}
+
+pub struct PriorityBuffer<T> {
+    sender: priotity_sender<T>,
+    high_buffer: VecDeque<T>,
+    normal_buffer: VecDeque<T>,
+}
+
+impl<T> PriorityBuffer<T> {
+    pub fn new(sender: priotity_sender<T>) -> Self {
+        PriorityBuffer {
+            sender,
+            high_buffer: VecDeque::default(),
+            normal_buffer: VecDeque::default(),
+        }
+    }
+
+    pub fn push_high(&mut self, item: T) {
+        self.high_buffer.push_back(item)
+    }
+
+    pub fn push_normal(&mut self, item: T) {
+        self.normal_buffer.push_back(item)
+    }
+
+    pub fn len(&self) -> usize {
+        self.high_buffer.len() + self.normal_buffer.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.high_buffer.is_empty() && self.normal_buffer.is_empty()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        if self.high_buffer.capacity() > self.high_buffer.len() + BUF_SHRINK_THRESHOLD {
+            self.high_buffer.shrink_to_fit();
+        }
+        if self.normal_buffer.capacity() > self.normal_buffer.len() + BUF_SHRINK_THRESHOLD {
+            self.normal_buffer.shrink_to_fit();
+        }
+    }
+
+    pub fn try_send(&mut self, cx: &mut Context) -> SendResult {
+        while let Some(event) = self.high_buffer.pop_front() {
+            match self.sender.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {
+                    if let Err(e) = self.sender.try_quick_send(event) {
+                        if e.is_full() {
+                            self.high_buffer.push_front(e.into_inner());
+                            return SendResult::Pending;
+                        } else {
+                            return SendResult::Disconnect;
+                        }
+                    }
+                }
+                Poll::Pending => {
+                    self.high_buffer.push_front(event);
+                    return SendResult::Pending;
+                }
+                Poll::Ready(Err(_)) => {
+                    self.high_buffer.clear();
+                    return SendResult::Disconnect;
+                }
+            }
+        }
+        while let Some(event) = self.normal_buffer.pop_front() {
+            match self.sender.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {
+                    if let Err(e) = self.sender.try_send(event) {
+                        if e.is_full() {
+                            self.normal_buffer.push_front(e.into_inner());
+                            return SendResult::Pending;
+                        } else {
+                            return SendResult::Disconnect;
+                        }
+                    }
+                }
+                Poll::Pending => {
+                    self.normal_buffer.push_front(event);
+                    return SendResult::Pending;
+                }
+                Poll::Ready(Err(_)) => {
+                    self.normal_buffer.clear();
+                    return SendResult::Disconnect;
+                }
+            }
+        }
+        self.shrink_to_fit();
+        SendResult::Ok
+    }
+}
+
+pub struct Buffer<T> {
+    sender: Sender<T>,
+    buffer: VecDeque<T>,
+}
+
+impl<T> Buffer<T> {
+    pub fn new(sender: Sender<T>) -> Self {
+        Buffer {
+            sender,
+            buffer: VecDeque::default(),
+        }
+    }
+
+    pub fn push(&mut self, item: T) {
+        self.buffer.push_back(item)
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        if self.buffer.capacity() > self.buffer.len() + BUF_SHRINK_THRESHOLD {
+            self.buffer.shrink_to_fit();
+        }
+    }
+
+    pub fn try_send(&mut self, cx: &mut Context) -> SendResult {
+        while let Some(event) = self.buffer.pop_front() {
+            match self.sender.poll_ready(cx) {
+                Poll::Ready(Ok(())) => {
+                    if let Err(e) = self.sender.try_send(event) {
+                        if e.is_full() {
+                            self.buffer.push_front(e.into_inner());
+                            return SendResult::Pending;
+                        } else {
+                            return SendResult::Disconnect;
+                        }
+                    }
+                }
+                Poll::Pending => {
+                    self.buffer.push_front(event);
+                    return SendResult::Pending;
+                }
+                Poll::Ready(Err(_)) => {
+                    self.buffer.clear();
+                    return SendResult::Disconnect;
+                }
+            }
+        }
+        self.shrink_to_fit();
+        SendResult::Ok
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Buffer, PriorityBuffer, Sender};
+    use crate::channel::mpsc::channel as priority_channel;
+    use futures::{channel::mpsc::channel, executor::block_on, future::poll_fn, StreamExt};
+    use std::{
+        collections::VecDeque,
+        task::{Context, Poll},
+    };
+
+    #[test]
+    fn test_priority_buffer() {
+        let (tx, mut rx) = priority_channel::<u32>(1);
+        let mut buffer = PriorityBuffer::new(tx);
+
+        buffer.push_high(1);
+        buffer.push_high(2);
+        buffer.push_high(3);
+        buffer.push_normal(4);
+        buffer.push_normal(5);
+
+        let send_1 = |cx: &mut Context<'_>| -> Poll<()> {
+            buffer.try_send(cx);
+            Poll::Ready(())
+        };
+        block_on(poll_fn(send_1));
+
+        assert_eq!(buffer.high_buffer, VecDeque::from(vec![3]));
+        assert_eq!(buffer.normal_buffer, VecDeque::from(vec![4, 5]));
+
+        let res: Vec<_> = block_on(async {
+            let mut a = Vec::new();
+            a.push(rx.next().await.unwrap().1);
+            a.push(rx.next().await.unwrap().1);
+            a
+        });
+
+        assert_eq!(res, vec![1, 2]);
+
+        let send_2 = |cx: &mut Context<'_>| -> Poll<()> {
+            buffer.try_send(cx);
+            Poll::Ready(())
+        };
+        block_on(poll_fn(send_2));
+
+        assert!(buffer.high_buffer.is_empty());
+        assert_eq!(buffer.normal_buffer, VecDeque::from(vec![5]));
+    }
+
+    #[test]
+    fn test_buffer() {
+        let (tx, mut rx) = channel::<u32>(1);
+        let mut buffer = Buffer::new(tx);
+
+        buffer.push(1);
+        buffer.push(2);
+        buffer.push(3);
+        buffer.push(4);
+        buffer.push(5);
+
+        let send_1 = |cx: &mut Context<'_>| -> Poll<()> {
+            buffer.try_send(cx);
+            Poll::Ready(())
+        };
+        block_on(poll_fn(send_1));
+
+        assert_eq!(buffer.buffer, VecDeque::from(vec![3, 4, 5]));
+
+        let res: Vec<_> = block_on(async {
+            let mut a = Vec::new();
+            a.push(rx.next().await.unwrap());
+            a.push(rx.next().await.unwrap());
+            a
+        });
+
+        assert_eq!(res, vec![1, 2]);
+
+        let send_2 = |cx: &mut Context<'_>| -> Poll<()> {
+            buffer.try_send(cx);
+            Poll::Ready(())
+        };
+        block_on(poll_fn(send_2));
+
+        assert_eq!(buffer.buffer, VecDeque::from(vec![5]));
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -47,6 +47,16 @@ impl SessionController {
         }
     }
 
+    pub(crate) fn push_message(&mut self, proto_id: ProtocolId, priority: Priority, data: Bytes) {
+        self.inner.incr_pending_data_size(data.len());
+        let message_event = SessionEvent::ProtocolMessage {
+            id: self.inner.id,
+            proto_id,
+            data,
+        };
+        self.push(priority, message_event)
+    }
+
     pub(crate) fn try_send(&mut self, cx: &mut Context) -> SendResult {
         self.buffer.try_send(cx)
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,12 +7,13 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
-    task::{Context, Poll},
+    task::Context,
     time::Duration,
 };
 
 use crate::{
-    channel::{mpsc, mpsc::Priority, SendError},
+    buffer::{PriorityBuffer, SendResult},
+    channel::{mpsc, mpsc::Priority},
     error::SendErrorKind,
     multiaddr::Multiaddr,
     protocol_select::ProtocolInfo,
@@ -23,7 +24,7 @@ use crate::{
 };
 
 pub(crate) struct SessionController {
-    event_sender: mpsc::Sender<SessionEvent>,
+    pub(crate) buffer: PriorityBuffer<SessionEvent>,
     pub(crate) inner: Arc<SessionContext>,
 }
 
@@ -33,28 +34,21 @@ impl SessionController {
         inner: Arc<SessionContext>,
     ) -> Self {
         Self {
-            event_sender,
+            buffer: PriorityBuffer::new(event_sender),
             inner,
         }
     }
 
-    pub(crate) fn try_send(
-        &mut self,
-        priority: Priority,
-        event: SessionEvent,
-    ) -> std::result::Result<(), mpsc::TrySendError<SessionEvent>> {
+    pub(crate) fn push(&mut self, priority: Priority, event: SessionEvent) {
         if priority.is_high() {
-            self.event_sender.try_quick_send(event)
+            self.buffer.push_high(event)
         } else {
-            self.event_sender.try_send(event)
+            self.buffer.push_normal(event)
         }
     }
 
-    pub(crate) fn poll_ready(
-        &mut self,
-        cx: &mut Context,
-    ) -> Poll<std::result::Result<(), SendError>> {
-        self.event_sender.poll_ready(cx)
+    pub(crate) fn try_send(&mut self, cx: &mut Context) -> SendResult {
+        self.buffer.try_send(cx)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub use secio;
 /// Re-pub yamux crate
 pub use yamux;
 
+/// Buffer management in distribution mode
+pub(crate) mod buffer;
 /// Some gadgets that help create a service
 pub mod builder;
 /// Context for Session and Service

--- a/src/substream.rs
+++ b/src/substream.rs
@@ -194,8 +194,8 @@ where
             log::trace!("sub stream poll shutdown err {}", e)
         }
 
-        if self.service_proto_sender.is_some() {
-            let (mut sender, mut events) = self.service_proto_sender.take().unwrap().take();
+        if let Some(ref mut service_proto_sender) = self.service_proto_sender {
+            let (mut sender, mut events) = service_proto_sender.take();
             events.push_back(ServiceProtocolEvent::Disconnected {
                 id: self.context.id,
             });
@@ -207,8 +207,8 @@ where
             });
         }
 
-        if self.session_proto_sender.is_some() {
-            let (mut sender, mut events) = self.session_proto_sender.take().unwrap().take();
+        if let Some(ref mut session_proto_sender) = self.session_proto_sender {
+            let (mut sender, mut events) = session_proto_sender.take();
             events.push_back(SessionProtocolEvent::Closed);
             if self.context.closed.load(Ordering::SeqCst) {
                 events.push_back(SessionProtocolEvent::Disconnected);


### PR DESCRIPTION
Use a unified buffer abstract structure to manage the entire tentacle buffer to facilitate testing

dependence #248 