### PR TITLE
fix: fix stream stuck after the underlying connection is closed

### DIFF
--- a/yamux/examples/yamux_simple.rs
+++ b/yamux/examples/yamux_simple.rs
@@ -59,8 +59,15 @@ fn run_client() {
         tokio::spawn(async move {
             loop {
                 match session.next().await {
-                    Some(_) => (),
-                    None => break,
+                    Some(Ok(_)) => (),
+                    Some(Err(e)) => {
+                        info!("{}", e);
+                        break;
+                    }
+                    None => {
+                        info!("closed");
+                        break;
+                    }
                 }
             }
         });

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -840,6 +840,12 @@ mod test {
         })
     }
 
+    // issue: https://github.com/nervosnetwork/tentacle/issues/259
+    // The reason for the problem is that when the session is closed,
+    // all stream states are not set to `RemoteClosed`
+    //
+    // This test can simulate a stuck state. If it is not set,
+    // the test will remain stuck and cannot be finished.
     #[test]
     fn test_close_session_on_stream_opened() {
         let mut rt = tokio::runtime::Runtime::new().unwrap();
@@ -859,7 +865,7 @@ mod test {
                 }
             });
 
-            let mut client = Session::new_server(remote, config);
+            let mut client = Session::new_client(remote, config);
 
             let mut control = client.control();
 

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -305,12 +305,14 @@ impl StreamHandle {
             }
 
             if self.frame_receiver.is_terminated() {
+                self.state = StreamState::RemoteClosing;
                 return Err(Error::SessionShutdown);
             }
 
             match Pin::new(&mut self.frame_receiver).as_mut().poll_next(cx) {
                 Poll::Ready(Some(frame)) => self.handle_frame(cx, frame)?,
                 Poll::Ready(None) => {
+                    self.state = StreamState::RemoteClosing;
                     return Err(Error::SessionShutdown);
                 }
                 Poll::Pending => break,


### PR DESCRIPTION
fix #259

When the session is closed, all streams need to be set to `RemoteClosed`