### PR TITLE
feat: Enable reuse port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio-util = { version = "0.3.0", features = ["codec"] }
 log = "0.4"
 bytes = "0.5.0"
 thiserror = "1.0"
+socket2 = { version = "0.3.15", features = ["reuseport"] }
 tokio-tungstenite = { version = "0.11", optional = true }
 
 flatbuffers = { version = "0.6.0", optional = true }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,6 +10,7 @@ use crate::{
         ProtocolHandle, ProtocolMeta, Service,
     },
     traits::{Codec, ServiceHandle, ServiceProtocol, SessionProtocol},
+    utils::multiaddr_to_socketaddr,
     yamux::Config,
     ProtocolId,
 };
@@ -116,7 +117,6 @@ impl ServiceBuilder {
     /// Whether to allow tentative registration upnp, default is disable(false)
     ///
     /// upnp: https://en.wikipedia.org/wiki/Universal_Plug_and_Play
-    /// TCP Hole Punching: http://bford.info/pub/net/p2pnat/
     ///
     /// Upnp is a simple solution to nat penetration, which requires routing support for registration mapping.
     ///
@@ -136,6 +136,25 @@ impl ServiceBuilder {
     /// Default is 65535
     pub fn max_connection_number(mut self, number: usize) -> Self {
         self.config.max_connection_number = number;
+        self
+    }
+
+    /// Bind all the outbound connections to the local listening address.
+    ///
+    /// In this way, any actively connected outbound connection is potentially connectable. Through this setting,
+    /// the device after NAT can have the opportunity to be connected to the public network.
+    ///
+    /// TCP Hole Punching: http://bford.info/pub/net/p2pnat/
+    /// STUN: https://tools.ietf.org/html/rfc5389
+    pub fn tcp_bind(mut self, addr: multiaddr::Multiaddr) -> Self {
+        self.config.tcp_bind_addr = multiaddr_to_socketaddr(&addr);
+        self
+    }
+
+    /// The same as tcp bind, but use on ws transport
+    #[cfg(feature = "ws")]
+    pub fn ws_bind(mut self, addr: multiaddr::Multiaddr) -> Self {
+        self.config.ws_bind_addr = multiaddr_to_socketaddr(&addr);
         self
     }
 

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -100,18 +100,12 @@ impl std::error::Error for SendError {}
 impl SendError {
     /// Returns `true` if this error is a result of the channel being full.
     pub fn is_full(&self) -> bool {
-        match self.kind {
-            SendErrorKind::Full => true,
-            _ => false,
-        }
+        matches!(self.kind, SendErrorKind::Full)
     }
 
     /// Returns `true` if this error is a result of the receiver being dropped.
     pub fn is_disconnected(&self) -> bool {
-        match self.kind {
-            SendErrorKind::Disconnected => true,
-            _ => false,
-        }
+        matches!(self.kind, SendErrorKind::Disconnected)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum TransportErrorKind {
     /// IO error
     #[error("transport io error: `{0:?}`")]
-    Io(IOError),
+    Io(#[from] IOError),
     /// Protocol not support
     #[error("multiaddr `{0:?}` is not supported")]
     NotSupported(Multiaddr),

--- a/src/service.rs
+++ b/src/service.rs
@@ -146,6 +146,7 @@ where
             before_sends: HashMap::default(),
             handle,
             multi_transport: {
+                #[allow(clippy::let_and_return)]
                 let transport = MultiTransport::new(config.timeout).tcp_bind(config.tcp_bind_addr);
                 #[cfg(feature = "ws")]
                 let transport = transport.ws_bind(config.ws_bind_addr);
@@ -1193,10 +1194,20 @@ where
             }
             ServiceTask::ProtocolOpen { session_id, target } => match target {
                 TargetProtocol::All => {
-                    let ids = self.protocol_configs.keys().copied().collect::<Vec<_>>();
-                    ids.into_iter().for_each(|id| {
-                        self.protocol_open(cx, session_id, id, String::default(), Source::External)
-                    });
+                    // Borrowed check attack
+                    #[allow(clippy::needless_collect)]
+                    {
+                        let ids = self.protocol_configs.keys().copied().collect::<Vec<_>>();
+                        ids.into_iter().for_each(|id| {
+                            self.protocol_open(
+                                cx,
+                                session_id,
+                                id,
+                                String::default(),
+                                Source::External,
+                            )
+                        });
+                    }
                 }
                 TargetProtocol::Single(id) => {
                     self.protocol_open(cx, session_id, id, String::default(), Source::External)

--- a/src/service.rs
+++ b/src/service.rs
@@ -145,7 +145,12 @@ where
             protocol_configs,
             before_sends: HashMap::default(),
             handle,
-            multi_transport: MultiTransport::new(config.timeout),
+            multi_transport: {
+                let transport = MultiTransport::new(config.timeout).tcp_bind(config.tcp_bind_addr);
+                #[cfg(feature = "ws")]
+                let transport = transport.ws_bind(config.ws_bind_addr);
+                transport
+            },
             future_task_sender: Buffer::new(future_task_sender),
             future_task_manager: Some(FutureTaskManager::new(
                 future_task_receiver,

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -4,9 +4,7 @@ use crate::{
     yamux::config::Config as YamuxConfig,
     ProtocolId, SessionId,
 };
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 
 /// Default max buffer size
 const MAX_BUF_SIZE: usize = 24 * 1024 * 1024;
@@ -20,6 +18,9 @@ pub(crate) struct ServiceConfig {
     pub keep_buffer: bool,
     pub upnp: bool,
     pub max_connection_number: usize,
+    pub tcp_bind_addr: Option<SocketAddr>,
+    #[cfg(feature = "ws")]
+    pub ws_bind_addr: Option<SocketAddr>,
 }
 
 impl Default for ServiceConfig {
@@ -32,6 +33,9 @@ impl Default for ServiceConfig {
             keep_buffer: false,
             upnp: false,
             max_connection_number: 65535,
+            tcp_bind_addr: None,
+            #[cfg(feature = "ws")]
+            ws_bind_addr: None,
         }
     }
 }

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -235,41 +235,25 @@ impl<T> ProtocolHandle<T> {
     /// Returns true if the enum is a callback value.
     #[inline]
     pub fn is_callback(&self) -> bool {
-        if let ProtocolHandle::Callback(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ProtocolHandle::Callback(_))
     }
 
     /// Returns true if the enum is a empty value.
     #[inline]
     pub fn is_neither(&self) -> bool {
-        if let ProtocolHandle::Neither = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ProtocolHandle::Neither)
     }
 
     /// Returns true if the enum is a event value.
     #[inline]
     pub fn is_event(&self) -> bool {
-        if let ProtocolHandle::Event = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ProtocolHandle::Event)
     }
 
     /// Returns true if the enum is a both value.
     #[inline]
     pub fn is_both(&self) -> bool {
-        if let ProtocolHandle::Both(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, ProtocolHandle::Both(_))
     }
 
     /// Returns true if the enum is a both value.

--- a/src/session.rs
+++ b/src/session.rs
@@ -921,18 +921,12 @@ pub(crate) enum SessionState {
 impl SessionState {
     #[inline]
     fn is_local_close(self) -> bool {
-        match self {
-            SessionState::LocalClose => true,
-            _ => false,
-        }
+        matches!(self, SessionState::LocalClose)
     }
 
     #[inline]
     fn is_normal(self) -> bool {
-        match self {
-            SessionState::Normal => true,
-            _ => false,
-        }
+        matches!(self, SessionState::Normal)
     }
 }
 

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -6,10 +6,12 @@ use crate::{
 
 use futures::{prelude::Stream, FutureExt};
 use log::debug;
+use socket2::{Domain, Protocol as SocketProtocol, Socket, Type};
 use std::{
     fmt,
     future::Future,
     io,
+    net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -45,11 +47,30 @@ pub trait Transport {
 #[derive(Clone, Copy)]
 pub struct MultiTransport {
     timeout: Duration,
+    tcp_bind: Option<SocketAddr>,
+    #[cfg(feature = "ws")]
+    ws_bind: Option<SocketAddr>,
 }
 
 impl MultiTransport {
     pub fn new(timeout: Duration) -> Self {
-        MultiTransport { timeout }
+        MultiTransport {
+            timeout,
+            tcp_bind: None,
+            #[cfg(feature = "ws")]
+            ws_bind: None,
+        }
+    }
+
+    pub fn tcp_bind(mut self, bind_addr: Option<SocketAddr>) -> Self {
+        self.tcp_bind = bind_addr;
+        self
+    }
+
+    #[cfg(feature = "ws")]
+    pub fn ws_bind(mut self, bind_addr: Option<SocketAddr>) -> Self {
+        self.ws_bind = bind_addr;
+        self
     }
 }
 
@@ -59,12 +80,15 @@ impl Transport for MultiTransport {
 
     fn listen(self, address: Multiaddr) -> Result<Self::ListenFuture> {
         match find_type(&address) {
-            TransportType::Tcp => match TcpTransport::new(self.timeout).listen(address) {
-                Ok(future) => Ok(MultiListenFuture::Tcp(future)),
-                Err(e) => Err(e),
-            },
+            TransportType::Tcp => {
+                match TcpTransport::new(self.timeout, self.tcp_bind).listen(address) {
+                    Ok(future) => Ok(MultiListenFuture::Tcp(future)),
+                    Err(e) => Err(e),
+                }
+            }
             #[cfg(feature = "ws")]
-            TransportType::Ws => match WsTransport::new(self.timeout).listen(address) {
+            TransportType::Ws => match WsTransport::new(self.timeout, self.ws_bind).listen(address)
+            {
                 Ok(future) => Ok(MultiListenFuture::Ws(future)),
                 Err(e) => Err(e),
             },
@@ -77,12 +101,14 @@ impl Transport for MultiTransport {
 
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
         match find_type(&address) {
-            TransportType::Tcp => match TcpTransport::new(self.timeout).dial(address) {
-                Ok(res) => Ok(MultiDialFuture::Tcp(res)),
-                Err(e) => Err(e),
-            },
+            TransportType::Tcp => {
+                match TcpTransport::new(self.timeout, self.tcp_bind).dial(address) {
+                    Ok(res) => Ok(MultiDialFuture::Tcp(res)),
+                    Err(e) => Err(e),
+                }
+            }
             #[cfg(feature = "ws")]
-            TransportType::Ws => match WsTransport::new(self.timeout).dial(address) {
+            TransportType::Ws => match WsTransport::new(self.timeout, self.ws_bind).dial(address) {
                 Ok(future) => Ok(MultiDialFuture::Ws(future)),
                 Err(e) => Err(e),
             },
@@ -262,6 +288,62 @@ pub fn find_type(addr: &Multiaddr) -> TransportType {
         }
     })
     .unwrap_or(TransportType::Tcp)
+}
+
+/// ws/tcp common listen realization
+#[inline(always)]
+async fn tcp_listen(addr: SocketAddr, reuse: bool) -> Result<(SocketAddr, TcpListener)> {
+    let tcp = if reuse {
+        let domain = match addr {
+            SocketAddr::V4(_) => Domain::ipv4(),
+            SocketAddr::V6(_) => Domain::ipv6(),
+        };
+        let socket = Socket::new(domain, Type::stream(), Some(SocketProtocol::tcp()))?;
+
+        // reuse addr and reuse port's situation on each platform
+        // https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ
+        #[cfg(unix)]
+        socket.set_reuse_port(true)?;
+
+        socket.set_reuse_address(true)?;
+        socket.bind(&addr.into())?;
+        socket.listen(1024)?;
+        TcpListener::from_std(socket.into_tcp_listener()).unwrap()
+    } else {
+        TcpListener::bind(&addr)
+            .await
+            .map_err(TransportErrorKind::Io)?
+    };
+
+    Ok((tcp.local_addr()?, tcp))
+}
+
+/// ws/tcp common dail realization
+#[inline(always)]
+async fn tcp_dail(
+    addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
+    timeout: Duration,
+) -> Result<TcpStream> {
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::ipv4(),
+        SocketAddr::V6(_) => Domain::ipv6(),
+    };
+    let socket = Socket::new(domain, Type::stream(), Some(SocketProtocol::tcp()))?;
+
+    if let Some(addr) = bind_addr {
+        #[cfg(unix)]
+        socket.set_reuse_port(true)?;
+        socket.set_reuse_address(true)?;
+        socket.bind(&addr.into())?;
+    }
+
+    let std_tcp = socket.into_tcp_stream();
+
+    match tokio::time::timeout(timeout, TcpStream::connect_std(std_tcp, &addr)).await {
+        Err(_) => Err(TransportErrorKind::Io(io::ErrorKind::TimedOut.into())),
+        Ok(res) => Ok(res?),
+    }
 }
 
 #[cfg(test)]

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -318,9 +318,9 @@ async fn tcp_listen(addr: SocketAddr, reuse: bool) -> Result<(SocketAddr, TcpLis
     Ok((tcp.local_addr()?, tcp))
 }
 
-/// ws/tcp common dail realization
+/// ws/tcp common dial realization
 #[inline(always)]
-async fn tcp_dail(
+async fn tcp_dial(
     addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     timeout: Duration,

--- a/src/transports/tcp.rs
+++ b/src/transports/tcp.rs
@@ -12,7 +12,7 @@ use tokio::net::{TcpListener, TcpStream};
 use crate::{
     error::TransportErrorKind,
     multiaddr::Multiaddr,
-    transports::{tcp_dail, tcp_listen, Transport},
+    transports::{tcp_dial, tcp_listen, Transport},
     utils::{dns::DNSResolver, multiaddr_to_socketaddr, socketaddr_to_multiaddr},
 };
 
@@ -44,7 +44,7 @@ async fn connect(
     let addr = address.await?;
     match multiaddr_to_socketaddr(&addr) {
         Some(socket_address) => {
-            let stream = tcp_dail(socket_address, bind_addr, timeout).await?;
+            let stream = tcp_dial(socket_address, bind_addr, timeout).await?;
             Ok((original.unwrap_or(addr), stream))
         }
         None => Err(TransportErrorKind::NotSupported(original.unwrap_or(addr))),

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -25,7 +25,7 @@ use tokio_tungstenite::{
 use crate::{
     error::TransportErrorKind,
     multiaddr::{Multiaddr, Protocol},
-    transports::{tcp_dail, tcp_listen, Result, Transport},
+    transports::{tcp_dial, tcp_listen, Result, Transport},
     utils::{dns::DNSResolver, multiaddr_to_socketaddr, socketaddr_to_multiaddr},
 };
 
@@ -59,7 +59,7 @@ async fn connect(
     match multiaddr_to_socketaddr(&addr) {
         Some(socket_address) => {
             let url = format!("ws://{}:{}", socket_address.ip(), socket_address.port());
-            let tcp = tcp_dail(socket_address, bind_addr, timeout).await?;
+            let tcp = tcp_dial(socket_address, bind_addr, timeout).await?;
 
             match tokio::time::timeout(timeout, client_async_with_config(url, tcp, None)).await {
                 Err(_) => Err(TransportErrorKind::Io(io::ErrorKind::TimedOut.into())),


### PR DESCRIPTION
Before this PR, the NAT penetration function that can be used is only UPnP routing registration, but it has some limitations. It can only pray that the node is behind a layer of NAT. If there are multiple layers of NAT, a single UPnP cannot public listen port to the public network. 

Multi-layer NAT penetration is a difficult and uncertain thing, the challenge is to get the TCP connect signal to be sent to the correct listening port on the intranet, so the problem becomes how to establish a mapping of intranet listening to public ports under multi-layer NAT.

As we can see, there is a protocol called [STUN](https://tools.ietf.org/html/rfc5389), which, at its core, allows an intranet node to know its extranet mapped address and port through the STUN server, and to keep that channel connected. At the same time, with the feature of port reuse, the src address and src port information of TCP are modified to the internal network listening port, and the TCP request connection signal of the external network can reach the internal network listening address through this channel, thereby establishing a connection.

The additional features of this PR will also affect the behavior of the discovery protocol. Previously, the discovery protocol could be called public discovery, but with port reuse enabled, it is possible to try to broadcast the channel on which the connection was made to the node behind NAT.

Now there is a question left, whether to be compatible with the Linux kernel before 3.9?