### PR TITLE
feat: remove aesctr, add x25519 support

### DIFF
--- a/fuzz/fuzz_targets/secio/crypto/decrypt_cipher.rs
+++ b/fuzz/fuzz_targets/secio/crypto/decrypt_cipher.rs
@@ -7,19 +7,10 @@ fn new_decrypt_cipher(cipher_type: CipherType) -> BoxStreamCipher {
     let key = (0..cipher_type.key_size())
         .map(|_| rand::random::<u8>())
         .collect::<Vec<_>>();
-    let iv = (0..cipher_type.iv_size())
-        .map(|_| rand::random::<u8>())
-        .collect::<Vec<_>>();
-    new_stream(cipher_type, &key, &iv, CryptoMode::Decrypt)
+    new_stream(cipher_type, &key, CryptoMode::Decrypt)
 }
 
 fuzz_target!(|data: &[u8]| {
-    let mut cipher = new_decrypt_cipher(CipherType::Aes128Ctr);
-    let _ = cipher.decrypt(data);
-
-    let mut cipher = new_decrypt_cipher(CipherType::Aes256Ctr);
-    let _ = cipher.decrypt(data);
-
     let mut cipher = new_decrypt_cipher(CipherType::Aes128Gcm);
     let _ = cipher.decrypt(data);
 

--- a/fuzz/fuzz_targets/secio/crypto/encrypt_cipher.rs
+++ b/fuzz/fuzz_targets/secio/crypto/encrypt_cipher.rs
@@ -7,19 +7,10 @@ fn new_encrypt_cipher(cipher_type: CipherType) -> BoxStreamCipher {
     let key = (0..cipher_type.key_size())
         .map(|_| rand::random::<u8>())
         .collect::<Vec<_>>();
-    let iv = (0..cipher_type.iv_size())
-        .map(|_| rand::random::<u8>())
-        .collect::<Vec<_>>();
-    new_stream(cipher_type, &key, &iv, CryptoMode::Encrypt)
+    new_stream(cipher_type, &key, CryptoMode::Encrypt)
 }
 
 fuzz_target!(|data: &[u8]| {
-    let mut cipher = new_encrypt_cipher(CipherType::Aes128Ctr);
-    let _ = cipher.encrypt(data);
-
-    let mut cipher = new_encrypt_cipher(CipherType::Aes256Ctr);
-    let _ = cipher.encrypt(data);
-
     let mut cipher = new_encrypt_cipher(CipherType::Aes128Gcm);
     let _ = cipher.encrypt(data);
 

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -39,7 +39,7 @@ openssl-sys = "0.9"
 [dev-dependencies]
 env_logger = "0.6"
 criterion = "0.3"
-tokio = { version = "0.2.0", features = ["tcp", "rt-core"] }
+tokio = { version = "0.2.0", features = ["tcp", "rt-core", "dns"] }
 
 [features]
 default = []

--- a/secio/benches/bench.rs
+++ b/secio/benches/bench.rs
@@ -1,51 +1,15 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
-use tentacle_secio::{
-    codec::Hmac,
-    crypto::{cipher::CipherType, new_stream, CryptoMode},
-};
+use tentacle_secio::crypto::{cipher::CipherType, new_stream, CryptoMode};
 
 fn decode_encode(data: &[u8], cipher: CipherType) {
     let cipher_key = (0..cipher.key_size())
         .map(|_| rand::random::<u8>())
         .collect::<Vec<_>>();
-    let _hmac_key: [u8; 32] = rand::random();
-    let iv = (0..cipher.iv_size())
-        .map(|_| rand::random::<u8>())
-        .collect::<Vec<_>>();
 
-    let mut encode_cipher = new_stream(cipher, &cipher_key, &iv, CryptoMode::Encrypt);
-    let mut decode_cipher = new_stream(cipher, &cipher_key, &iv, CryptoMode::Decrypt);
-    let (mut decode_hmac, mut encode_hmac): (Option<Hmac>, Option<Hmac>) = match cipher {
-        CipherType::ChaCha20Poly1305 | CipherType::Aes128Gcm | CipherType::Aes256Gcm => {
-            (None, None)
-        }
-        #[cfg(unix)]
-        _ => {
-            use tentacle_secio::Digest;
-            let encode_hmac = Hmac::from_key(Digest::Sha256, &_hmac_key);
-            let decode_hmac = encode_hmac.clone();
-            (Some(decode_hmac), Some(encode_hmac))
-        }
-    };
+    let mut encode_cipher = new_stream(cipher, &cipher_key, CryptoMode::Encrypt);
+    let mut decode_cipher = new_stream(cipher, &cipher_key, CryptoMode::Decrypt);
 
-    let mut encode_data = encode_cipher.encrypt(&data[..]).unwrap();
-    if encode_hmac.is_some() {
-        let signature = encode_hmac.as_mut().unwrap().sign(&encode_data[..]);
-        encode_data.extend_from_slice(signature.as_ref());
-    }
-
-    if decode_hmac.is_some() {
-        let content_length = encode_data.len() - decode_hmac.as_mut().unwrap().num_bytes();
-
-        let (crypted_data, expected_hash) = encode_data.split_at(content_length);
-
-        assert!(decode_hmac
-            .as_mut()
-            .unwrap()
-            .verify(crypted_data, expected_hash));
-
-        encode_data.truncate(content_length);
-    }
+    let encode_data = encode_cipher.encrypt(&data[..]).unwrap();
 
     let decode_data = decode_cipher.decrypt(&encode_data).unwrap();
 
@@ -62,16 +26,6 @@ fn criterion_benchmark(bench: &mut Criterion) {
     let data = (0..1024 * 256)
         .map(|_| rand::random::<u8>())
         .collect::<Vec<_>>();
-    #[cfg(unix)]
-    bench.bench_function("1kb_aes128ctr", {
-        let data = data.clone();
-        move |b| bench_test(b, CipherType::Aes128Ctr, &data)
-    });
-    #[cfg(unix)]
-    bench.bench_function("1kb_aes256ctr", {
-        let data = data.clone();
-        move |b| bench_test(b, CipherType::Aes256Ctr, &data)
-    });
     bench.bench_function("1kb_aes128gcm", {
         let data = data.clone();
         move |b| bench_test(b, CipherType::Aes128Gcm, &data)
@@ -87,16 +41,6 @@ fn criterion_benchmark(bench: &mut Criterion) {
     let data = (0..1024 * 1024)
         .map(|_| rand::random::<u8>())
         .collect::<Vec<_>>();
-    #[cfg(unix)]
-    bench.bench_function("1mb_aes128ctr", {
-        let data = data.clone();
-        move |b| bench_test(b, CipherType::Aes128Ctr, &data)
-    });
-    #[cfg(unix)]
-    bench.bench_function("1mb_aes256ctr", {
-        let data = data.clone();
-        move |b| bench_test(b, CipherType::Aes256Ctr, &data)
-    });
     bench.bench_function("1mb_aes128gcm", {
         let data = data.clone();
         move |b| bench_test(b, CipherType::Aes128Gcm, &data)

--- a/secio/src/crypto/cipher.rs
+++ b/secio/src/crypto/cipher.rs
@@ -1,16 +1,8 @@
-#[cfg(unix)]
-use openssl::symm::Cipher as OpensslCipher;
 use ring::aead;
 
 /// Possible encryption ciphers.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CipherType {
-    /// Aes128Ctr
-    #[cfg(unix)]
-    Aes128Ctr,
-    /// Aes256Ctr
-    #[cfg(unix)]
-    Aes256Ctr,
     /// Aes128Gcm
     Aes128Gcm,
     /// Aes256Gcm
@@ -23,10 +15,6 @@ impl CipherType {
     /// Returns the size of in bytes of the key expected by the cipher.
     pub fn key_size(self) -> usize {
         match self {
-            #[cfg(unix)]
-            CipherType::Aes128Ctr => OpensslCipher::aes_128_ctr().key_len(),
-            #[cfg(unix)]
-            CipherType::Aes256Ctr => OpensslCipher::aes_256_ctr().key_len(),
             CipherType::Aes128Gcm => aead::AES_128_GCM.key_len(),
             CipherType::Aes256Gcm => aead::AES_256_GCM.key_len(),
             CipherType::ChaCha20Poly1305 => aead::CHACHA20_POLY1305.key_len(),
@@ -37,10 +25,6 @@ impl CipherType {
     #[inline]
     pub fn iv_size(self) -> usize {
         match self {
-            #[cfg(unix)]
-            CipherType::Aes128Ctr => OpensslCipher::aes_128_ctr().iv_len().unwrap_or_default(),
-            #[cfg(unix)]
-            CipherType::Aes256Ctr => OpensslCipher::aes_256_ctr().iv_len().unwrap_or_default(),
             CipherType::Aes128Gcm => aead::AES_128_GCM.nonce_len(),
             CipherType::Aes256Gcm => aead::AES_256_GCM.nonce_len(),
             CipherType::ChaCha20Poly1305 => aead::CHACHA20_POLY1305.nonce_len(),
@@ -51,10 +35,6 @@ impl CipherType {
     #[inline]
     pub fn tag_size(self) -> usize {
         match self {
-            #[cfg(unix)]
-            CipherType::Aes128Ctr => 0,
-            #[cfg(unix)]
-            CipherType::Aes256Ctr => 0,
             CipherType::Aes128Gcm => aead::AES_128_GCM.tag_len(),
             CipherType::Aes256Gcm => aead::AES_256_GCM.tag_len(),
             CipherType::ChaCha20Poly1305 => aead::CHACHA20_POLY1305.tag_len(),

--- a/secio/src/crypto/ring_impl.rs
+++ b/secio/src/crypto/ring_impl.rs
@@ -46,11 +46,6 @@ impl RingAeadCipher {
             CipherType::Aes128Gcm => &AES_128_GCM,
             CipherType::Aes256Gcm => &AES_256_GCM,
             CipherType::ChaCha20Poly1305 => &CHACHA20_POLY1305,
-            #[cfg(unix)]
-            _ => panic!(
-                "Cipher type {:?} does not supported by RingAead yet",
-                cipher_type
-            ),
         };
 
         let cipher = match mode {

--- a/secio/src/exchange.rs
+++ b/secio/src/exchange.rs
@@ -11,6 +11,7 @@ use crate::error::SecioError;
 pub enum KeyAgreement {
     EcdhP256,
     EcdhP384,
+    X25519,
 }
 
 impl Into<&'static agreement::Algorithm> for KeyAgreement {
@@ -19,6 +20,7 @@ impl Into<&'static agreement::Algorithm> for KeyAgreement {
         match self {
             KeyAgreement::EcdhP256 => &agreement::ECDH_P256,
             KeyAgreement::EcdhP384 => &agreement::ECDH_P384,
+            KeyAgreement::X25519 => &agreement::X25519,
         }
     }
 }

--- a/secio/src/support.rs
+++ b/secio/src/support.rs
@@ -9,15 +9,7 @@ use std::cmp::Ordering;
 
 const ECDH_P256: &str = "P-256";
 const ECDH_P384: &str = "P-384";
-
-#[cfg(unix)]
-const AES_128: &str = "AES-128";
-#[cfg(unix)]
-const AES_256: &str = "AES-256";
-#[cfg(unix)]
-const AES_128_CTR: &str = "AES-128-CTR";
-#[cfg(unix)]
-const AES_256_CTR: &str = "AES-256-CTR";
+const X25519: &str = "X25519";
 
 const AES_128_GCM: &str = "AES-128-GCM";
 const AES_256_GCM: &str = "AES-256-GCM";
@@ -27,11 +19,7 @@ const CHACHA20_POLY1305: &str = "CHACHA20_POLY1305";
 const SHA_256: &str = "SHA256";
 const SHA_512: &str = "SHA512";
 
-pub(crate) const DEFAULT_AGREEMENTS_PROPOSITION: &str = "P-256,P-384";
-#[cfg(unix)]
-pub(crate) const DEFAULT_CIPHERS_PROPOSITION: &str =
-    "AES-128-GCM,AES-256-GCM,CHACHA20_POLY1305,AES-128-CTR,AES-256-CTR,AES-128,AES-256";
-#[cfg(not(unix))]
+pub(crate) const DEFAULT_AGREEMENTS_PROPOSITION: &str = "P-256,P-384,X25519";
 pub(crate) const DEFAULT_CIPHERS_PROPOSITION: &str = "AES-128-GCM,AES-256-GCM,CHACHA20_POLY1305";
 pub(crate) const DEFAULT_DIGESTS_PROPOSITION: &str = "SHA256,SHA512";
 
@@ -49,6 +37,10 @@ where
             }
             KeyAgreement::EcdhP384 => {
                 s.push_str(ECDH_P384);
+                s.push(',')
+            }
+            KeyAgreement::X25519 => {
+                s.push_str(X25519);
                 s.push(',')
             }
         }
@@ -71,6 +63,7 @@ pub fn select_agreement(r: Ordering, ours: &str, theirs: &str) -> Result<KeyAgre
             match x {
                 ECDH_P256 => return Ok(KeyAgreement::EcdhP256),
                 ECDH_P384 => return Ok(KeyAgreement::EcdhP384),
+                X25519 => return Ok(KeyAgreement::X25519),
                 _ => continue,
             }
         }
@@ -86,16 +79,6 @@ where
     let mut s = String::new();
     for c in ciphers {
         match c {
-            #[cfg(unix)]
-            CipherType::Aes128Ctr => {
-                s.push_str(AES_128_CTR);
-                s.push(',')
-            }
-            #[cfg(unix)]
-            CipherType::Aes256Ctr => {
-                s.push_str(AES_256_CTR);
-                s.push(',')
-            }
             CipherType::Aes128Gcm => {
                 s.push_str(AES_128_GCM);
                 s.push(',')
@@ -169,10 +152,6 @@ pub fn select_cipher(r: Ordering, ours: &str, theirs: &str) -> Result<CipherType
     for x in a.split(',') {
         if b.split(',').any(|y| x == y) {
             match x {
-                #[cfg(unix)]
-                AES_128 | AES_128_CTR => return Ok(CipherType::Aes128Ctr),
-                #[cfg(unix)]
-                AES_256 | AES_256_CTR => return Ok(CipherType::Aes256Ctr),
                 AES_128_GCM => return Ok(CipherType::Aes128Gcm),
                 AES_256_GCM => return Ok(CipherType::Aes256Gcm),
                 CHACHA20_POLY1305 => return Ok(CipherType::ChaCha20Poly1305),


### PR DESCRIPTION
review #269 first
Why do this？
Because only in this way can the next step of development be carried out when the review speed is extremely slow

---

1. remove aes ctr support
2. add x25519 support