### PR TITLE
chore: bump to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.2
+
+### Features
+- Change channel api to immutable(#265)
+- Enable reuse port, use to NAT penetration(#266)
+- Make yamux independent of the specific runtime(#267,#268)
+- Make tentacle run on async std(#269)
+- Add fuzz test(#211)
+
 ## 0.3.1
 
 ### Features

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <441594700@qq.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -16,7 +16,7 @@ all-features = false
 no-default-features = true
 
 [dependencies]
-yamux = { path = "../yamux", version = "0.2.6", default-features = false, package = "tokio-yamux"}
+yamux = { path = "../yamux", version = "0.2.7", default-features = false, package = "tokio-yamux"}
 secio = { path = "../secio", version = "0.4.1", package = "tentacle-secio" }
 
 futures = { version = "0.3.0" }

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-yamux"
-version = "0.2.6"
+version = "0.2.7"
 license = "MIT"
 repository = "https://github.com/nervosnetwork/tentacle"
 description = "Rust implementation of Yamux"


### PR DESCRIPTION
The next PRs are all related to wasm, we can package a version of the stable feature first