### PR TITLE
feat: add protocol spawn feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ fmt:
 	cargo fmt --all -- --check
 
 clippy:
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo clippy --all --tests --features molc,ws -- -D clippy::let_underscore_must_use
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo clippy --all --tests --features flatc -- -D clippy::let_underscore_must_use
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo clippy --all --tests --features molc,ws,unstable -- -D clippy::let_underscore_must_use
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo clippy --all --tests --features flatc,unstable -- -D clippy::let_underscore_must_use
 
 test:
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features molc,ws
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features flatc
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features molc,ws,unstable
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --features flatc,unstable
 
 fuzz:
 	cargo +nightly fuzz run secio_crypto_decrypt_cipher -- -max_total_time=60
@@ -35,21 +35,22 @@ fuzz:
 
 build:
 	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features molc,ws
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features flatc
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features molc,ws,unstable
+	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features flatc,unstable
 
 examples:
-	$(Change_Work_Path) && cargo build --examples --all --features molc
-	$(Change_Work_Path) && cargo build --examples --all --features flatc
+	$(Change_Work_Path) && cargo build --examples --all --features molc,unstable
+	$(Change_Work_Path) && cargo build --examples --all --features flatc,unstable
 
 features-check:
 	# remove yamux default features
 	sed -i 's/"tokio-timer"//g' yamux/Cargo.toml
-	$(Change_Work_Path) && cargo build --features molc
-	$(Change_Work_Path) && cargo build --features molc,tokio-runtime,generic-timer --no-default-features
-	$(Change_Work_Path) && cargo build --features molc,async-runtime,generic-timer --no-default-features
-	$(Change_Work_Path) && cargo build --features molc,async-runtime,async-timer --no-default-features
+	$(Change_Work_Path) && cargo build --features molc,unstable
+	$(Change_Work_Path) && cargo build --features molc,tokio-runtime,generic-timer,unstable --no-default-features
+	$(Change_Work_Path) && cargo build --features molc,async-runtime,generic-timer,unstable --no-default-features
+	$(Change_Work_Path) && cargo build --features molc,async-runtime,async-timer,unstable --no-default-features
 	# required wasm32-unknown-unknown target
-	$(Change_Work_Path) && cargo build --features molc,wasm-timer --no-default-features --target=wasm32-unknown-unknown
+	$(Change_Work_Path) && cargo build --features molc,wasm-timer,unstable --no-default-features --target=wasm32-unknown-unknown
 	git checkout .
 
 bench_p2p:

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -74,7 +74,7 @@ tokio-timer = ["yamux/tokio-timer", "tokio/time", "tokio-runtime"]
 tokio-runtime = ["tokio/io-util", "tokio/tcp", "tokio/dns", "tokio/rt-threaded", "tokio/blocking"]
 
 async-timer = ["async-runtime"]
-async-runtime = ["async-std", "async-io", "yamux/generic-timer", "tokio-util/compat"]
+async-runtime = ["async-std", "async-io", "yamux/generic-timer"]
 
 generic-timer = ["futures-timer", "yamux/generic-timer"]
 wasm-timer = ["futures-timer", "yamux/wasm", "futures-timer/wasm-bindgen"]

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -67,7 +67,7 @@ flatc = [ "flatbuffers", "flatbuffers-verifier", "secio/flatc" ]
 # use molecule to handshake
 molc = [ "molecule", "secio/molc" ]
 ws = ["tokio-tungstenite"]
-
+unstable = []
 # Related to runtime
 
 tokio-timer = ["yamux/tokio-timer", "tokio/time", "tokio-runtime"]

--- a/tentacle/examples/simple_using_spawn.rs
+++ b/tentacle/examples/simple_using_spawn.rs
@@ -1,3 +1,6 @@
+#![cfg(feature = "unstable")]
+
+/// Implement simple.rs example using `ProtocolSpawn`.
 use bytes::Bytes;
 use env_logger;
 use futures::StreamExt;

--- a/tentacle/examples/use_spawn.rs
+++ b/tentacle/examples/use_spawn.rs
@@ -1,0 +1,183 @@
+use bytes::Bytes;
+use env_logger;
+use futures::StreamExt;
+use log::info;
+use std::{str, sync::Arc, time::Duration};
+use tentacle::{
+    builder::{MetaBuilder, ServiceBuilder},
+    context::{ServiceContext, SessionContext},
+    secio::SecioKeyPair,
+    service::{
+        ProtocolMeta, Service, ServiceAsyncControl, ServiceControl, ServiceError, ServiceEvent,
+        TargetProtocol, TargetSession,
+    },
+    traits::{ProtocolSpawn, ServiceHandle},
+    ProtocolId, SubstreamReadPart,
+};
+
+struct ProtocolStream;
+
+impl ProtocolSpawn for ProtocolStream {
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        control: &ServiceControl,
+        mut read_part: SubstreamReadPart,
+    ) {
+        let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+        tokio::spawn(async move {
+            info!(
+                "{}, {:?}, {}, opened",
+                context.id,
+                context.ty,
+                read_part.protocol_id()
+            );
+            if read_part.protocol_id() == 1.into() {
+                let mut c = control.clone();
+                let pid = read_part.protocol_id();
+                let mut interval =
+                    tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
+                tokio::spawn(async move {
+                    loop {
+                        interval.tick().await;
+                        let _ = c
+                            .filter_broadcast(
+                                TargetSession::All,
+                                pid,
+                                Bytes::from("I am a interval message"),
+                            )
+                            .await;
+                    }
+                });
+            }
+            loop {
+                if let Some(Ok(data)) = read_part.next().await {
+                    info!(
+                        "received from [{}]: proto [{}] data {:?}",
+                        context.id,
+                        read_part.protocol_id(),
+                        str::from_utf8(data.as_ref()).unwrap(),
+                    );
+                    if context.ty.is_outbound() {
+                        let pid = read_part.protocol_id();
+                        let _ = control.send_message_to(context.id, pid, data).await;
+                    }
+                } else {
+                    break;
+                }
+            }
+            info!(
+                "{}, {:?}, {}, closed",
+                context.id,
+                context.ty,
+                read_part.protocol_id()
+            );
+        });
+    }
+}
+
+fn create_meta(id: ProtocolId) -> ProtocolMeta {
+    MetaBuilder::new()
+        .id(id)
+        .protocol_spawn(ProtocolStream)
+        .build()
+}
+
+struct SHandle;
+
+impl ServiceHandle for SHandle {
+    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+        info!("service error: {:?}", error);
+    }
+    fn handle_event(&mut self, context: &mut ServiceContext, event: ServiceEvent) {
+        info!("service event: {:?}", event);
+        if let ServiceEvent::SessionOpen { .. } = event {
+            let delay_sender = context.control().clone();
+
+            let _ = context.future_task(async move {
+                tokio::time::delay_until(tokio::time::Instant::now() + Duration::from_secs(3))
+                    .await;
+                let _ = delay_sender.filter_broadcast(
+                    TargetSession::All,
+                    0.into(),
+                    Bytes::from("I am a delayed message"),
+                );
+            });
+        }
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    if std::env::args().nth(1) == Some("server".to_string()) {
+        info!("Starting server ......");
+        server();
+    } else {
+        info!("Starting client ......");
+        client();
+    }
+}
+
+fn create_server() -> Service<SHandle> {
+    ServiceBuilder::default()
+        .insert_protocol(create_meta(0.into()))
+        .insert_protocol(create_meta(1.into()))
+        .key_pair(SecioKeyPair::secp256k1_generated())
+        .build(SHandle)
+}
+
+/// Proto 0 open success
+/// Proto 1 open success
+/// Proto 2 open failure
+///
+/// Because server only supports 0,1
+fn create_client() -> Service<SHandle> {
+    ServiceBuilder::default()
+        .insert_protocol(create_meta(0.into()))
+        .insert_protocol(create_meta(1.into()))
+        .insert_protocol(create_meta(2.into()))
+        .key_pair(SecioKeyPair::secp256k1_generated())
+        .build(SHandle)
+}
+
+fn server() {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let mut service = create_server();
+        service
+            .listen("/ip4/127.0.0.1/tcp/1337".parse().unwrap())
+            .await
+            .unwrap();
+        service
+            .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
+            .await
+            .unwrap();
+        loop {
+            if service.next().await.is_none() {
+                break;
+            }
+        }
+    });
+}
+
+fn client() {
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let mut service = create_client();
+        service
+            .dial(
+                "/ip4/127.0.0.1/tcp/1337".parse().unwrap(),
+                TargetProtocol::All,
+            )
+            .await
+            .unwrap();
+        loop {
+            if service.next().await.is_none() {
+                break;
+            }
+        }
+    });
+}

--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -274,6 +274,7 @@ impl MetaBuilder {
     /// Define the spawn process of the protocol read part
     ///
     /// Mutually exclusive with protocol handle
+    #[cfg(feature = "unstable")]
     pub fn protocol_spawn<T: ProtocolSpawn + Send + Sync + 'static>(mut self, spawn: T) -> Self {
         self.spawn = Some(Box::new(spawn));
         self

--- a/tentacle/src/lib.rs
+++ b/tentacle/src/lib.rs
@@ -21,6 +21,8 @@
     target_arch = "wasm32",
     allow(dead_code, unused_variables, unused_imports)
 )]
+// delete until break change
+#![allow(deprecated)]
 
 /// Re-pub bytes crate
 pub use bytes;
@@ -63,6 +65,8 @@ mod runtime;
 pub(crate) mod upnp;
 
 use std::{fmt, ops::AddAssign};
+
+pub use substream::SubstreamReadPart;
 
 /// Index of sub/protocol stream
 type StreamId = usize;

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -83,7 +83,7 @@ mod os {
         ) -> Poll<io::Result<(TcpStream, SocketAddr)>> {
             match self.recv.poll_next_unpin(cx) {
                 Poll::Ready(Some(res)) => {
-                    Poll::Ready(res.map(|x| (TcpStream(CompatStream2(x.0)), x.1)))
+                    Poll::Ready(res.map(|x| (TcpStream(CompatStream2::new(x.0)), x.1)))
                 }
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(None) => Poll::Ready(Err(io::ErrorKind::BrokenPipe.into())),
@@ -171,7 +171,7 @@ mod os {
         match stream.get_ref().take_error()? {
             None => {
                 let tcp = stream.into_inner().unwrap();
-                Ok(TcpStream(CompatStream2(AsyncStream::from(tcp))))
+                Ok(TcpStream(CompatStream2::new(AsyncStream::from(tcp))))
             }
             Some(err) => Err(err),
         }

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -13,6 +13,7 @@ pub use os::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod os {
+    use crate::runtime::CompatStream2;
     use async_io::Async;
     use async_std::net::{TcpListener as AsyncListener, TcpStream as AsyncStream, ToSocketAddrs};
     use futures::{
@@ -21,14 +22,13 @@ mod os {
             oneshot::{self, Sender},
         },
         future::select,
-        AsyncRead as _, FutureExt, SinkExt, StreamExt,
+        FutureExt, SinkExt, StreamExt,
     };
     use std::{
         pin::Pin,
         task::{Context, Poll},
     };
     use tokio::prelude::{AsyncRead, AsyncWrite};
-    use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 
     #[derive(Debug)]
     pub struct TcpListener {
@@ -83,7 +83,7 @@ mod os {
         ) -> Poll<io::Result<(TcpStream, SocketAddr)>> {
             match self.recv.poll_next_unpin(cx) {
                 Poll::Ready(Some(res)) => {
-                    Poll::Ready(res.map(|x| (TcpStream(x.0.compat_write()), x.1)))
+                    Poll::Ready(res.map(|x| (TcpStream(CompatStream2(x.0)), x.1)))
                 }
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(None) => Poll::Ready(Err(io::ErrorKind::BrokenPipe.into())),
@@ -92,7 +92,7 @@ mod os {
     }
 
     #[derive(Debug)]
-    pub struct TcpStream(Compat<AsyncStream>);
+    pub struct TcpStream(CompatStream2<AsyncStream>);
 
     impl TcpStream {
         pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -106,7 +106,7 @@ mod os {
             cx: &mut Context<'_>,
             buf: &mut [u8],
         ) -> Poll<Result<usize, io::Error>> {
-            Pin::new(self.0.get_mut()).poll_read(cx, buf)
+            AsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
         }
     }
 
@@ -171,7 +171,7 @@ mod os {
         match stream.get_ref().take_error()? {
             None => {
                 let tcp = stream.into_inner().unwrap();
-                Ok(TcpStream(AsyncStream::from(tcp).compat_write()))
+                Ok(TcpStream(CompatStream2(AsyncStream::from(tcp))))
             }
             Some(err) => Err(err),
         }

--- a/tentacle/src/runtime/mod.rs
+++ b/tentacle/src/runtime/mod.rs
@@ -39,9 +39,11 @@ mod generic_split {
     pub type ReadHalf<T> = CompatStream2<R<CompatStream<T>>>;
     pub type WriteHalf<T> = CompatStream2<W<CompatStream<T>>>;
 
+    /// Splits a single value implementing `AsyncRead + AsyncWrite` into separate
+    /// `AsyncRead` and `AsyncWrite` handles.
     pub fn split<T: AsyncRead + AsyncWrite + Unpin>(io: T) -> (ReadHalf<T>, WriteHalf<T>) {
-        let (read, write) = CompatStream(io).split();
-        (CompatStream2(read), CompatStream2(write))
+        let (read, write) = CompatStream::new(io).split();
+        (CompatStream2::new(read), CompatStream2::new(write))
     }
 }
 
@@ -214,11 +216,45 @@ where
 }
 
 impl<T> CompatStream2<T> {
+    /// New wrapped stream
+    pub fn new(stream: T) -> Self {
+        CompatStream2(stream)
+    }
+
+    /// Get a reference to the Future, Stream, AsyncRead, or AsyncWrite object contained within.
     pub fn get_ref(&self) -> &T {
         &self.0
     }
 
+    /// Get a mutable reference to the Future, Stream, AsyncRead, or AsyncWrite object contained within.
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.0
+    }
+
+    /// Returns the wrapped item.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> CompatStream<T> {
+    /// New wrapped stream
+    pub fn new(stream: T) -> Self {
+        CompatStream(stream)
+    }
+
+    /// Get a reference to the Future, Stream, AsyncRead, or AsyncWrite object contained within.
+    pub fn get_ref(&self) -> &T {
+        &self.0
+    }
+
+    /// Get a mutable reference to the Future, Stream, AsyncRead, or AsyncWrite object contained within.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+
+    /// Returns the wrapped item.
+    pub fn into_inner(self) -> T {
+        self.0
     }
 }

--- a/tentacle/src/runtime/mod.rs
+++ b/tentacle/src/runtime/mod.rs
@@ -23,3 +23,202 @@ pub use generic_timer::*;
 pub use tokio_runtime::*;
 #[cfg(target_arch = "wasm32")]
 pub use wasm_runtime::*;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "tokio-runtime"))]
+pub use tokio::io::{split, ReadHalf, WriteHalf};
+
+#[cfg(not(feature = "tokio-runtime"))]
+pub use generic_split::*;
+
+#[cfg(not(feature = "tokio-runtime"))]
+mod generic_split {
+    use super::{CompatStream, CompatStream2};
+    use futures::io::{AsyncReadExt, ReadHalf as R, WriteHalf as W};
+    use tokio::prelude::{AsyncRead, AsyncWrite};
+
+    pub type ReadHalf<T> = CompatStream2<R<CompatStream<T>>>;
+    pub type WriteHalf<T> = CompatStream2<W<CompatStream<T>>>;
+
+    pub fn split<T: AsyncRead + AsyncWrite + Unpin>(io: T) -> (ReadHalf<T>, WriteHalf<T>) {
+        let (read, write) = CompatStream(io).split();
+        (CompatStream2(read), CompatStream2(write))
+    }
+}
+
+use futures::{AsyncRead as FutureAsyncRead, AsyncWrite as FutureAsyncWrite};
+use std::{
+    fmt, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::prelude::{AsyncRead, AsyncWrite};
+
+/// Compact tokio to future
+pub struct CompatStream<T>(T);
+
+impl<T> FutureAsyncRead for CompatStream<T>
+where
+    T: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncRead::poll_read(self, cx, buf)
+    }
+}
+
+impl<T> FutureAsyncWrite for CompatStream<T>
+where
+    T: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(self, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_shutdown(self, cx)
+    }
+}
+
+impl<T> AsyncRead for CompatStream<T>
+where
+    T: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
+    }
+}
+
+impl<T> AsyncWrite for CompatStream<T>
+where
+    T: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(Pin::new(&mut self.0), cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(Pin::new(&mut self.0), cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_shutdown(Pin::new(&mut self.0), cx)
+    }
+}
+
+/// Compact future to tokio
+pub struct CompatStream2<T>(T);
+
+impl<T> AsyncRead for CompatStream2<T>
+where
+    T: FutureAsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        FutureAsyncRead::poll_read(self, cx, buf)
+    }
+}
+
+impl<T> AsyncWrite for CompatStream2<T>
+where
+    T: FutureAsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        FutureAsyncWrite::poll_write(self, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        FutureAsyncWrite::poll_flush(self, cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        FutureAsyncWrite::poll_close(self, cx)
+    }
+}
+
+impl<T> FutureAsyncRead for CompatStream2<T>
+where
+    T: FutureAsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        FutureAsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
+    }
+}
+
+impl<T> FutureAsyncWrite for CompatStream2<T>
+where
+    T: FutureAsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        FutureAsyncWrite::poll_write(Pin::new(&mut self.0), cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        FutureAsyncWrite::poll_flush(Pin::new(&mut self.0), cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        FutureAsyncWrite::poll_close(Pin::new(&mut self.0), cx)
+    }
+}
+
+impl<T> fmt::Debug for CompatStream2<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T> fmt::Debug for CompatStream<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T> CompatStream2<T> {
+    pub fn get_ref(&self) -> &T {
+        &self.0
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -607,7 +607,7 @@ where
         let target = self
             .dial_protocols
             .remove(&address)
-            .unwrap_or_else(|| TargetProtocol::All);
+            .unwrap_or(TargetProtocol::All);
         if let Some(ref key) = remote_pubkey {
             // If the public key exists, the connection has been established
             // and then the useless connection needs to be closed.

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -698,6 +698,7 @@ where
             self.config.timeout,
             session_context.clone(),
             service_event_sender,
+            self.service_context.control().clone(),
         )
         .protocol_by_name(by_name)
         .protocol_by_id(by_id)

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     builder::{BeforeReceiveFn, CodecFn, NameFn, SelectVersionFn, SessionHandleFn},
-    traits::{Codec, ServiceProtocol, SessionProtocol},
+    traits::{Codec, ProtocolSpawn, ServiceProtocol, SessionProtocol},
     yamux::config::Config as YamuxConfig,
     ProtocolId, SessionId,
 };
@@ -202,6 +202,7 @@ pub(crate) struct Meta {
     pub(crate) codec: CodecFn,
     pub(crate) select_version: SelectVersionFn,
     pub(crate) before_receive: BeforeReceiveFn,
+    pub(crate) spawn: Option<Box<dyn ProtocolSpawn + Send + Sync + 'static>>,
 }
 
 /// Protocol handle Contains four modes, each of which has a corresponding behavior,

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 use tokio::prelude::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{Framed, FramedParts, LengthDelimitedCodec};
+use tokio_util::codec::{Framed, FramedParts, FramedRead, FramedWrite, LengthDelimitedCodec};
 use yamux::{Control, Session as YamuxSession, StreamHandle};
 
 use crate::{
@@ -24,11 +24,11 @@ use crate::{
     service::{
         config::{Meta, SessionConfig},
         future_task::BoxedFutureTask,
-        SessionType, RECEIVED_BUFFER_SIZE, RECEIVED_SIZE, SEND_SIZE,
+        ServiceControl, SessionType, RECEIVED_BUFFER_SIZE, RECEIVED_SIZE, SEND_SIZE,
     },
-    substream::{ProtocolEvent, SubstreamBuilder},
+    substream::{PatchedReadPart, ProtocolEvent, SubstreamBuilder, SubstreamWritePartBuilder},
     transports::MultiIncoming,
-    ProtocolId, SessionId, StreamId,
+    ProtocolId, SessionId, StreamId, SubstreamReadPart,
 };
 
 pub trait AsyncRW: AsyncWrite + AsyncRead {}
@@ -161,6 +161,7 @@ pub(crate) struct Session {
     state: SessionState,
 
     context: Arc<SessionContext>,
+    service_control: ServiceControl,
 
     next_stream: StreamId,
 
@@ -229,6 +230,7 @@ impl Session {
             config: meta.config,
             timeout: meta.timeout,
             context: meta.context,
+            service_control: meta.service_control,
             keep_buffer: meta.keep_buffer,
             next_stream: 0,
             substreams: HashMap::default(),
@@ -398,38 +400,76 @@ impl Session {
         if self.proto_streams.contains_key(&proto_id) {
             return;
         }
+
         let before_receive_fn = (proto.before_receive)();
-        let raw_part = substream.into_parts();
-        let mut part = FramedParts::new(raw_part.io, (proto.codec)());
-        // Replace buffered data
-        part.read_buf = raw_part.read_buf;
-        part.write_buf = raw_part.write_buf;
-        let frame = Framed::from_parts(part);
         let (session_to_proto_sender, session_to_proto_receiver) =
             priority_mpsc::channel(SEND_SIZE);
 
-        let mut proto_stream = SubstreamBuilder::new(
-            self.proto_event_sender.clone(),
-            session_to_proto_receiver,
-            self.context.clone(),
-        )
-        .proto_id(proto_id)
-        .stream_id(self.next_stream)
-        .config(self.config)
-        .service_proto_sender(self.service_proto_senders.get(&proto_id).cloned())
-        .session_proto_sender(self.session_proto_senders.get(&proto_id).cloned())
-        .keep_buffer(self.keep_buffer)
-        .event(self.event.contains(&proto_id))
-        .before_receive(before_receive_fn)
-        .build(frame);
-
         self.substreams.insert(
             self.next_stream,
-            PriorityBuffer::new(session_to_proto_sender),
+            PriorityBuffer::new(session_to_proto_sender.clone()),
         );
         self.proto_streams.insert(proto_id, self.next_stream);
+        let raw_part = substream.into_parts();
 
-        proto_stream.proto_open(version.clone());
+        match proto.spawn {
+            Some(ref spawn) => {
+                let (read, write) = crate::runtime::split(raw_part.io);
+                let read_part = {
+                    let frame = FramedRead::new(
+                        PatchedReadPart::new(read, raw_part.read_buf),
+                        (proto.codec)(),
+                    );
+
+                    SubstreamReadPart {
+                        substream: frame,
+                        before_receive: before_receive_fn,
+                        proto_id,
+                        stream_id: self.next_stream,
+                        version: version.clone(),
+                        close_sender: session_to_proto_sender,
+                    }
+                };
+
+                let write_part = SubstreamWritePartBuilder::new(
+                    self.proto_event_sender.clone(),
+                    session_to_proto_receiver,
+                    self.context.clone(),
+                )
+                .proto_id(proto_id)
+                .stream_id(self.next_stream)
+                .config(self.config)
+                .build(FramedWrite::new(write, (proto.codec)()));
+
+                crate::runtime::spawn(write_part.for_each(|_| future::ready(())));
+                spawn.spawn(self.context.clone(), &self.service_control, read_part);
+            }
+            None => {
+                let mut part = FramedParts::new(raw_part.io, (proto.codec)());
+                // Replace buffered data
+                part.read_buf = raw_part.read_buf;
+                part.write_buf = raw_part.write_buf;
+                let frame = Framed::from_parts(part);
+
+                let mut proto_stream = SubstreamBuilder::new(
+                    self.proto_event_sender.clone(),
+                    session_to_proto_receiver,
+                    self.context.clone(),
+                )
+                .proto_id(proto_id)
+                .stream_id(self.next_stream)
+                .config(self.config)
+                .service_proto_sender(self.service_proto_senders.get(&proto_id).cloned())
+                .session_proto_sender(self.session_proto_senders.get(&proto_id).cloned())
+                .keep_buffer(self.keep_buffer)
+                .event(self.event.contains(&proto_id))
+                .before_receive(before_receive_fn)
+                .build(frame);
+
+                proto_stream.proto_open(version.clone());
+                crate::runtime::spawn(proto_stream.for_each(|_| future::ready(())));
+            }
+        }
 
         if self.event.contains(&proto_id) {
             self.event_output(
@@ -445,7 +485,6 @@ impl Session {
         self.next_stream += 1;
 
         debug!("session [{}] proto [{}] open", self.context.id, proto_id);
-        crate::runtime::spawn(proto_stream.for_each(|_| future::ready(())));
     }
 
     /// Handling events uploaded by the protocol stream
@@ -827,6 +866,7 @@ pub(crate) struct SessionMeta {
     session_proto_senders: HashMap<ProtocolId, Buffer<SessionProtocolEvent>>,
     event: HashSet<ProtocolId>,
     event_sender: priority_mpsc::Sender<SessionEvent>,
+    service_control: ServiceControl,
     session_proto_handles: Vec<(
         Option<futures::channel::oneshot::Sender<()>>,
         crate::runtime::JoinHandle<()>,
@@ -838,6 +878,7 @@ impl SessionMeta {
         timeout: Duration,
         context: Arc<SessionContext>,
         event_sender: priority_mpsc::Sender<SessionEvent>,
+        control: ServiceControl,
     ) -> Self {
         SessionMeta {
             config: SessionConfig::default(),
@@ -850,6 +891,7 @@ impl SessionMeta {
             session_proto_senders: HashMap::default(),
             event: HashSet::new(),
             session_proto_handles: Vec::new(),
+            service_control: control,
             event_sender,
         }
     }

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -1,4 +1,4 @@
-use futures::{channel::mpsc, prelude::*, stream::iter};
+use futures::{channel::mpsc, prelude::*, stream::iter, SinkExt, StreamExt};
 use log::debug;
 use std::{
     collections::VecDeque,
@@ -7,8 +7,8 @@ use std::{
     sync::{atomic::Ordering, Arc},
     task::{Context, Poll},
 };
-use tokio::prelude::AsyncWrite;
-use tokio_util::codec::{length_delimited::LengthDelimitedCodec, Framed};
+use tokio::prelude::{AsyncRead, AsyncWrite};
+use tokio_util::codec::{length_delimited::LengthDelimitedCodec, Framed, FramedRead, FramedWrite};
 
 use crate::{
     buffer::{Buffer, SendResult},
@@ -616,6 +616,435 @@ impl SubstreamBuilder {
             service_proto_sender: self.service_proto_sender,
             session_proto_sender: self.session_proto_sender,
             before_receive: self.before_receive,
+        }
+    }
+}
+
+/* Code organization under read-write separation */
+
+pub(crate) struct SubstreamWritePart<U> {
+    substream: FramedWrite<crate::runtime::WriteHalf<StreamHandle>, U>,
+    id: StreamId,
+    proto_id: ProtocolId,
+
+    dead: bool,
+    config: SessionConfig,
+
+    /// The buffer will be prioritized for send to underlying network
+    high_write_buf: VecDeque<bytes::Bytes>,
+    // The buffer which will send to underlying network
+    write_buf: VecDeque<bytes::Bytes>,
+
+    /// Send event to session
+    event_sender: Buffer<ProtocolEvent>,
+    /// Receive events from session
+    event_receiver: priority_mpsc::Receiver<ProtocolEvent>,
+
+    context: Arc<SessionContext>,
+}
+
+impl<U> SubstreamWritePart<U>
+where
+    U: Codec + Unpin,
+{
+    fn push_front(&mut self, priority: Priority, frame: bytes::Bytes) {
+        if priority.is_high() {
+            self.high_write_buf.push_front(frame);
+        } else {
+            self.write_buf.push_front(frame);
+        }
+    }
+
+    fn push_back(&mut self, priority: Priority, frame: bytes::Bytes) {
+        if priority.is_high() {
+            self.high_write_buf.push_back(frame);
+        } else {
+            self.write_buf.push_back(frame);
+        }
+    }
+
+    /// Sink `start_send` Ready -> data in buffer or send
+    /// Sink `start_send` NotReady -> buffer full need poll complete
+    #[inline]
+    fn send_inner(
+        &mut self,
+        cx: &mut Context,
+        frame: bytes::Bytes,
+        priority: Priority,
+    ) -> Result<bool, io::Error> {
+        let data_size = frame.len();
+        let mut sink = Pin::new(&mut self.substream);
+
+        match sink.as_mut().poll_ready(cx)? {
+            Poll::Ready(()) => {
+                sink.as_mut().start_send(frame)?;
+                self.context.decr_pending_data_size(data_size);
+                Ok(false)
+            }
+            Poll::Pending => {
+                debug!("framed_stream NotReady, frame len: {:?}", frame.len());
+                self.push_front(priority, frame);
+                Ok(true)
+            }
+        }
+    }
+
+    fn poll_complete(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
+        match Pin::new(&mut self.substream).poll_flush(cx) {
+            Poll::Pending => Ok(true),
+            Poll::Ready(res) => res.map(|_| false),
+        }
+    }
+
+    /// Send data to the lower `yamux` sub stream
+    fn send_data(&mut self, cx: &mut Context) -> Result<(), io::Error> {
+        while let Some(frame) = self.high_write_buf.pop_front() {
+            if self.send_inner(cx, frame, Priority::High)? && self.poll_complete(cx)? {
+                return Ok(());
+            }
+        }
+
+        while let Some(frame) = self.write_buf.pop_front() {
+            if self.send_inner(cx, frame, Priority::Normal)? && self.poll_complete(cx)? {
+                return Ok(());
+            }
+        }
+
+        self.poll_complete(cx)?;
+
+        debug!("send success, proto_id: {}", self.proto_id);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self, cx: &mut Context) -> Result<(), io::Error> {
+        if !self.event_sender.is_empty()
+            || !self.write_buf.is_empty()
+            || !self.high_write_buf.is_empty()
+        {
+            self.output(cx);
+
+            match self.send_data(cx) {
+                Ok(()) => Ok(()),
+                Err(err) => Err(err),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Handling commands send by session
+    fn handle_proto_event(&mut self, cx: &mut Context, event: ProtocolEvent, priority: Priority) {
+        match event {
+            ProtocolEvent::Message { data, .. } => {
+                debug!("proto [{}] send data: {}", self.proto_id, data.len());
+                self.push_back(priority, data);
+
+                if let Err(err) = self.send_data(cx) {
+                    // Whether it is a read send error or a flush error,
+                    // the most essential problem is that there is a problem with the external network.
+                    // Close the protocol stream directly.
+                    debug!(
+                        "protocol [{}] close because of extern network",
+                        self.proto_id
+                    );
+                    self.output_event(
+                        cx,
+                        ProtocolEvent::Error {
+                            id: self.id,
+                            proto_id: self.proto_id,
+                            error: err,
+                        },
+                    );
+                    self.dead = true;
+                }
+            }
+            ProtocolEvent::Close { .. } => {
+                self.write_buf.clear();
+                self.dead = true;
+            }
+            _ => (),
+        }
+    }
+
+    fn recv_event(&mut self, cx: &mut Context) -> Poll<Option<()>> {
+        if self.dead {
+            return Poll::Ready(None);
+        }
+
+        if self.write_buf.len() > self.config.send_event_size() {
+            return Poll::Pending;
+        }
+
+        match Pin::new(&mut self.event_receiver).as_mut().poll_next(cx) {
+            Poll::Ready(Some((priority, event))) => {
+                self.handle_proto_event(cx, event, priority);
+                Poll::Ready(Some(()))
+            }
+            Poll::Ready(None) => {
+                // Must be session close
+                self.dead = true;
+                if let Poll::Ready(Err(e)) = Pin::new(self.substream.get_mut()).poll_shutdown(cx) {
+                    log::trace!("sub stream poll shutdown err {}", e)
+                }
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// When send or receive message error, output error and close stream
+    fn error_close(&mut self, cx: &mut Context, error: io::Error) {
+        self.dead = true;
+        self.event_sender.push(ProtocolEvent::Error {
+            id: self.id,
+            proto_id: self.proto_id,
+            error,
+        });
+        self.close_proto_stream(cx);
+    }
+
+    fn close_proto_stream(&mut self, cx: &mut Context) {
+        self.event_receiver.close();
+        if let Poll::Ready(Err(e)) = Pin::new(self.substream.get_mut()).poll_shutdown(cx) {
+            log::trace!("sub stream poll shutdown err {}", e)
+        }
+        if !self.context.closed.load(Ordering::SeqCst) {
+            let (mut sender, mut events) = self.event_sender.take();
+            events.push_back(ProtocolEvent::Close {
+                id: self.id,
+                proto_id: self.proto_id,
+            });
+            crate::runtime::spawn(async move {
+                let mut iter = iter(events).map(Ok);
+                if let Err(e) = sender.send_all(&mut iter).await {
+                    debug!("stream close event send to session error: {:?}", e)
+                }
+            });
+        } else {
+            self.output(cx);
+        }
+    }
+
+    /// Send event to user
+    #[inline]
+    fn output_event(&mut self, cx: &mut Context, event: ProtocolEvent) {
+        self.event_sender.push(event);
+        self.output(cx);
+    }
+
+    #[inline]
+    fn output(&mut self, cx: &mut Context) {
+        if let SendResult::Disconnect = self.event_sender.try_send(cx) {
+            debug!("proto send to session error: disconnect, may be kill by remote");
+            self.dead = true;
+        }
+    }
+}
+
+impl<U> Stream for SubstreamWritePart<U>
+where
+    U: Codec + Unpin,
+{
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        // double check here
+        if self.dead || self.context.closed.load(Ordering::SeqCst) {
+            debug!(
+                "Substream({}) finished, self.dead || self.context.closed.load(Ordering::SeqCst), head",
+                self.id
+            );
+            self.close_proto_stream(cx);
+            return Poll::Ready(None);
+        }
+
+        if let Err(err) = self.flush(cx) {
+            debug!(
+                "Substream({}) finished with flush error: {:?}",
+                self.id, err
+            );
+            self.error_close(cx, err);
+            return Poll::Ready(None);
+        }
+
+        debug!(
+            "write buf: {}, read buf: {}",
+            self.write_buf.len(),
+            self.event_sender.len()
+        );
+
+        let is_pending = self.recv_event(cx).is_pending();
+
+        if self.dead || self.context.closed.load(Ordering::SeqCst) {
+            debug!(
+                "Substream({}) finished, self.dead || self.context.closed.load(Ordering::SeqCst), tail",
+                self.id
+            );
+            self.close_proto_stream(cx);
+            return Poll::Ready(None);
+        }
+
+        if is_pending {
+            Poll::Pending
+        } else {
+            Poll::Ready(Some(()))
+        }
+    }
+}
+
+/// Protocol Stream read part
+pub struct SubstreamReadPart {
+    pub(crate) substream: FramedRead<PatchedReadPart, Box<dyn Codec + Send + 'static>>,
+    pub(crate) before_receive: Option<BeforeReceive>,
+    pub(crate) proto_id: ProtocolId,
+    pub(crate) stream_id: StreamId,
+    pub(crate) version: String,
+    pub(crate) close_sender: priority_mpsc::Sender<ProtocolEvent>,
+}
+
+impl SubstreamReadPart {
+    /// protocol id of this stream
+    pub fn protocol_id(&self) -> ProtocolId {
+        self.proto_id
+    }
+    /// protocol version
+    pub fn version(&self) -> &str {
+        self.version.as_str()
+    }
+}
+
+impl Drop for SubstreamReadPart {
+    fn drop(&mut self) {
+        let mut sender = self.close_sender.clone();
+        let id = self.stream_id;
+        let pid = self.proto_id;
+        crate::runtime::spawn(async move {
+            let _ignore = sender
+                .send(ProtocolEvent::Close { id, proto_id: pid })
+                .await;
+        });
+    }
+}
+
+impl Stream for SubstreamReadPart {
+    type Item = Result<bytes::Bytes, io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        match self.substream.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(data))) => {
+                let data = match self.before_receive {
+                    Some(ref function) => match function(data) {
+                        Ok(data) => data,
+                        Err(err) => {
+                            return Poll::Ready(Some(Err(err)));
+                        }
+                    },
+                    None => data.freeze(),
+                };
+                Poll::Ready(Some(Ok(data)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub(crate) struct SubstreamWritePartBuilder {
+    id: StreamId,
+    proto_id: ProtocolId,
+    config: SessionConfig,
+
+    context: Arc<SessionContext>,
+
+    /// Send event to session
+    event_sender: mpsc::Sender<ProtocolEvent>,
+    /// Receive events from session
+    event_receiver: priority_mpsc::Receiver<ProtocolEvent>,
+}
+
+impl SubstreamWritePartBuilder {
+    pub fn new(
+        event_sender: mpsc::Sender<ProtocolEvent>,
+        event_receiver: priority_mpsc::Receiver<ProtocolEvent>,
+        context: Arc<SessionContext>,
+    ) -> Self {
+        SubstreamWritePartBuilder {
+            event_receiver,
+            event_sender,
+            context,
+            id: 0,
+            proto_id: 0.into(),
+            config: SessionConfig::default(),
+        }
+    }
+
+    pub fn stream_id(mut self, id: StreamId) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn proto_id(mut self, id: ProtocolId) -> Self {
+        self.proto_id = id;
+        self
+    }
+
+    pub fn config(mut self, config: SessionConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn build<U>(
+        self,
+        substream: FramedWrite<crate::runtime::WriteHalf<StreamHandle>, U>,
+    ) -> SubstreamWritePart<U>
+    where
+        U: Codec,
+    {
+        SubstreamWritePart {
+            substream,
+            id: self.id,
+            proto_id: self.proto_id,
+            config: self.config,
+            context: self.context,
+
+            high_write_buf: VecDeque::new(),
+
+            write_buf: VecDeque::new(),
+            dead: false,
+
+            event_sender: Buffer::new(self.event_sender),
+            event_receiver: self.event_receiver,
+        }
+    }
+}
+
+/// Remove after https://github.com/tokio-rs/tokio/pull/3166 merge
+pub(crate) struct PatchedReadPart {
+    buffer: bytes::BytesMut,
+    io: crate::runtime::ReadHalf<StreamHandle>,
+}
+
+impl PatchedReadPart {
+    pub fn new(io: crate::runtime::ReadHalf<StreamHandle>, buffer: bytes::BytesMut) -> Self {
+        Self { io, buffer }
+    }
+}
+
+impl AsyncRead for PatchedReadPart {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        if self.buffer.is_empty() {
+            Pin::new(&mut self.io).poll_read(cx, buf)
+        } else {
+            let n = ::std::cmp::min(buf.len(), self.buffer.len());
+            let b = self.buffer.split_to(n);
+            buf[..n].copy_from_slice(&b);
+            Poll::Ready(Ok(n))
         }
     }
 }

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -155,13 +155,13 @@ where
     /// Send data to the lower `yamux` sub stream
     fn send_data(&mut self, cx: &mut Context) -> Result<(), io::Error> {
         while let Some(frame) = self.high_write_buf.pop_front() {
-            if self.send_inner(cx, frame, Priority::High)? && self.poll_complete(cx)? {
+            if self.send_inner(cx, frame, Priority::High)? {
                 return Ok(());
             }
         }
 
         while let Some(frame) = self.write_buf.pop_front() {
-            if self.send_inner(cx, frame, Priority::Normal)? && self.poll_complete(cx)? {
+            if self.send_inner(cx, frame, Priority::Normal)? {
                 return Ok(());
             }
         }
@@ -699,13 +699,13 @@ where
     /// Send data to the lower `yamux` sub stream
     fn send_data(&mut self, cx: &mut Context) -> Result<(), io::Error> {
         while let Some(frame) = self.high_write_buf.pop_front() {
-            if self.send_inner(cx, frame, Priority::High)? && self.poll_complete(cx)? {
+            if self.send_inner(cx, frame, Priority::High)? {
                 return Ok(());
             }
         }
 
         while let Some(frame) = self.write_buf.pop_front() {
-            if self.send_inner(cx, frame, Priority::Normal)? && self.poll_complete(cx)? {
+            if self.send_inner(cx, frame, Priority::Normal)? {
                 return Ok(());
             }
         }

--- a/tentacle/src/traits.rs
+++ b/tentacle/src/traits.rs
@@ -116,11 +116,13 @@ pub trait SessionProtocol {
 /// When the negotiation is completed and the agreement is opened, will call the implementation,
 /// allow users to implement the read processing of the protocol by themselves
 ///
-/// Implementing this trait means that streaming reading will become possible, and at the same time,
-/// async methods that cannot be used due to Rust's temporary lack of support on async trait will also become possible
+/// Implementing this trait means that streaming reading directly from the underlying substream
+/// will become possible, and at the same time, async methods that cannot be used due to Rust's
+/// temporary lack of support on async trait will also become possible
 ///
 /// This trait implementation and the callback implementation are mutually exclusive, and will be
 /// checked during construction, if both exist, it will panic
+#[cfg_attr(not(feature = "unstable"), doc(hidden))]
 pub trait ProtocolSpawn {
     /// Call on protocol opened
     fn spawn(

--- a/tentacle/src/traits.rs
+++ b/tentacle/src/traits.rs
@@ -1,13 +1,15 @@
 use std::{
     io,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::{
-    context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
-    service::{ProtocolEvent, ServiceError, ServiceEvent},
+    context::{ProtocolContext, ProtocolContextMutRef, ServiceContext, SessionContext},
+    service::{ProtocolEvent, ServiceControl, ServiceError, ServiceEvent},
+    substream::SubstreamReadPart,
 };
 
 /// Service handle
@@ -37,6 +39,7 @@ pub trait ServiceHandle {
     ///
     /// If the handle of the protocol has event, then its events will be placed here.
     /// If there is no event handle in the protocol, this interface will not be called.
+    #[deprecated(since = "0.3.5", note = "use `ProtocolSpawn` instead")]
     fn handle_proto(&mut self, _control: &mut ServiceContext, _event: ProtocolEvent) {}
 }
 
@@ -108,6 +111,24 @@ pub trait SessionProtocol {
     ) -> Poll<Option<()>> {
         Poll::Ready(None)
     }
+}
+
+/// When the negotiation is completed and the agreement is opened, will call the implementation,
+/// allow users to implement the read processing of the protocol by themselves
+///
+/// Implementing this trait means that streaming reading will become possible, and at the same time,
+/// async methods that cannot be used due to Rust's temporary lack of support on async trait will also become possible
+///
+/// This trait implementation and the callback implementation are mutually exclusive, and will be
+/// checked during construction, if both exist, it will panic
+pub trait ProtocolSpawn {
+    /// Call on protocol opened
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        control: &ServiceControl,
+        read_part: SubstreamReadPart,
+    );
 }
 
 /// A trait can define codec, just wrapper `Decoder` and `Encoder`

--- a/tentacle/tests/test_protocol_open_close_on_spawn.rs
+++ b/tentacle/tests/test_protocol_open_close_on_spawn.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "unstable")]
 use futures::StreamExt;
 use std::{
     sync::mpsc::channel,

--- a/tentacle/tests/test_protocol_open_close_on_spawn.rs
+++ b/tentacle/tests/test_protocol_open_close_on_spawn.rs
@@ -1,0 +1,198 @@
+use futures::StreamExt;
+use std::{
+    sync::mpsc::channel,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+use tentacle::{
+    builder::{MetaBuilder, ServiceBuilder},
+    context::SessionContext,
+    multiaddr::Multiaddr,
+    secio::SecioKeyPair,
+    service::{ProtocolMeta, Service, ServiceAsyncControl, ServiceControl, TargetProtocol},
+    traits::{ProtocolSpawn, ServiceHandle},
+    SubstreamReadPart,
+};
+
+/// test case:
+/// 1. open with dummy session protocol
+/// 2. dummy protocol open test protocol
+/// 3. test protocol open/close self 10 times, each closed count + 1
+/// 4. when count >= 10, test done
+
+#[derive(Clone)]
+struct Dummy;
+
+impl ProtocolSpawn for Dummy {
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        control: &ServiceControl,
+        _read_part: SubstreamReadPart,
+    ) {
+        // dummy open the test protocol
+        control.open_protocol(context.id, 1.into()).unwrap()
+        // protocol close here
+    }
+}
+
+struct PHandle {
+    count: Arc<AtomicUsize>,
+    once: AtomicBool,
+}
+
+impl ProtocolSpawn for PHandle {
+    fn spawn(
+        &self,
+        context: Arc<SessionContext>,
+        control: &ServiceControl,
+        mut read_part: SubstreamReadPart,
+    ) {
+        let id = context.id;
+        let pid = read_part.protocol_id();
+        let is_outbound = context.ty.is_outbound();
+
+        if is_outbound && self.once.load(Ordering::Relaxed) {
+            self.once.store(false, Ordering::Relaxed);
+            let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval_at(
+                    tokio::time::Instant::now(),
+                    Duration::from_millis(100),
+                );
+                loop {
+                    interval.tick().await;
+                    control.open_protocol(id, pid).await.unwrap();
+                }
+            });
+        }
+
+        if is_outbound {
+            let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+
+            tokio::spawn(async move {
+                control.close_protocol(id, pid).await.unwrap();
+            });
+        }
+
+        let count = self.count.clone();
+        let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+        tokio::spawn(async move {
+            while let Some(Ok(_)) = read_part.next().await {}
+            if is_outbound {
+                count.fetch_add(1, Ordering::SeqCst);
+                if count.load(Ordering::SeqCst) >= 10 {
+                    let _ignore = control.shutdown().await;
+                }
+            }
+        });
+    }
+}
+
+pub fn create<F>(secio: bool, metas: impl Iterator<Item = ProtocolMeta>, shandle: F) -> Service<F>
+where
+    F: ServiceHandle + Unpin,
+{
+    let mut builder = ServiceBuilder::default().forever(true);
+
+    for meta in metas {
+        builder = builder.insert_protocol(meta);
+    }
+
+    if secio {
+        builder
+            .key_pair(SecioKeyPair::secp256k1_generated())
+            .build(shandle)
+    } else {
+        builder.build(shandle)
+    }
+}
+
+fn test_session_proto_open_close(secio: bool) {
+    let p_handle_1 = PHandle {
+        count: Arc::new(AtomicUsize::new(0)),
+        once: AtomicBool::new(true),
+    };
+    let p_handle_2 = PHandle {
+        count: Arc::new(AtomicUsize::new(0)),
+        once: AtomicBool::new(true),
+    };
+
+    let meta_dummy_1 = MetaBuilder::new()
+        .id(0.into())
+        .protocol_spawn(Dummy)
+        .build();
+
+    let meta_dummy_2 = MetaBuilder::new()
+        .id(0.into())
+        .protocol_spawn(Dummy)
+        .build();
+
+    let meta_1 = MetaBuilder::new()
+        .id(1.into())
+        .protocol_spawn(p_handle_1)
+        .build();
+
+    let meta_2 = MetaBuilder::new()
+        .id(1.into())
+        .protocol_spawn(p_handle_2)
+        .build();
+
+    let mut service_1 = create(secio, vec![meta_dummy_1, meta_1].into_iter(), ());
+    let mut service_2 = create(secio, vec![meta_dummy_2, meta_2].into_iter(), ());
+
+    let (addr_sender, addr_receiver) = channel::<Multiaddr>();
+
+    thread::spawn(move || {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            let listen_addr = service_2
+                .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+                .await
+                .unwrap();
+
+            addr_sender.send(listen_addr).unwrap();
+
+            loop {
+                if service_2.next().await.is_none() {
+                    break;
+                }
+            }
+        });
+    });
+
+    let listen_addr = addr_receiver.recv().unwrap();
+
+    let handle = thread::spawn(move || {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            service_1
+                .dial(listen_addr, TargetProtocol::Single(0.into()))
+                .await
+                .unwrap();
+
+            loop {
+                if service_1.next().await.is_none() {
+                    break;
+                }
+            }
+        });
+    });
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_spawn_proto_open_close_with_secio() {
+    test_session_proto_open_close(true)
+}
+
+#[test]
+fn test_spawn_proto_open_close_with_no_secio() {
+    test_session_proto_open_close(false)
+}


### PR DESCRIPTION
In order to allow users to achieve a fully streamed reading and writing experience, and to bypass the problem of the async trait.

I add an interface that is mutually exclusive with the previous callback model. It can get all the information required by the protocol, suitable for async environment