### PR TITLE
chore: replace unnecessary fold by `.map(..).sum()`

### DIFF
--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -61,10 +61,7 @@ impl Bench {
 
     fn output(&mut self, name: &str) {
         self.executed_time_list.sort();
-        let total = self
-            .executed_time_list
-            .iter()
-            .fold(Duration::default(), |start, &x| start + x);
+        let total = self.executed_time_list.iter().sum::<Duration>();
         println!(
             "task name: {}\ncycles: {}\ntotal cost: {:?}\naverage: {:?}\nmedian: {:?}\nmax: {:?}\nmin: {:?}\n",
             name,

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -1280,7 +1280,8 @@ where
         if self
             .sessions
             .values()
-            .fold(0, |acc, item| acc + item.buffer.len())
+            .map(|item| item.buffer.len())
+            .sum::<usize>()
             > self.config.session_config.send_event_size()
         {
             // The write buffer exceeds the expected range, and no longer receives any event
@@ -1311,12 +1312,14 @@ where
         if self
             .service_proto_handles
             .values()
-            .fold(0, |acc, item| acc + item.len())
+            .map(Buffer::len)
+            .sum::<usize>()
             > self.config.session_config.recv_event_size()
             || self
                 .session_proto_handles
                 .values()
-                .fold(0, |acc, item| acc + item.len())
+                .map(Buffer::len)
+                .sum::<usize>()
                 > self.config.session_config.recv_event_size()
         {
             // The read buffer exceeds the expected range, and no longer receives any event
@@ -1443,13 +1446,16 @@ where
                 self.future_task_sender.len(),
                 self.sessions
                     .values()
-                    .fold(0, |acc, item| acc + item.buffer.len()),
+                    .map(|item| item.buffer.len())
+                    .sum::<usize>(),
                 self.service_proto_handles
                     .values()
-                    .fold(0, |acc, item| acc + item.len()),
+                    .map(Buffer::len)
+                    .sum::<usize>(),
                 self.session_proto_handles
                     .values()
-                    .fold(0, |acc, item| acc + item.len()),
+                    .map(Buffer::len)
+                    .sum::<usize>(),
             );
         }
 

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -635,7 +635,8 @@ impl Session {
         if self
             .substreams
             .values()
-            .fold(0, |acc, item| acc + item.len())
+            .map(PriorityBuffer::len)
+            .sum::<usize>()
             > RECEIVED_BUFFER_SIZE
         {
             // The write buffer exceeds the expected range, and no longer receives any event
@@ -758,7 +759,8 @@ impl Stream for Session {
                 self.service_sender.len(),
                 self.substreams
                     .values()
-                    .fold(0, |acc, item| acc + item.len()),
+                    .map(PriorityBuffer::len)
+                    .sum::<usize>(),
             );
         }
 


### PR DESCRIPTION
The usage of `fold` is a little ugly.