### PR TITLE
fix: yamux session flush must once a loop

### DIFF
--- a/secio/src/handshake/procedure.rs
+++ b/secio/src/handshake/procedure.rs
@@ -247,6 +247,7 @@ where
     secure_stream
         .write_all(&pub_ephemeral_context.state.remote.nonce)
         .await?;
+    secure_stream.flush().await?;
     secure_stream.verify_nonce().await?;
 
     Ok((

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -594,10 +594,6 @@ where
             return Poll::Ready(None);
         }
 
-        self.flush(cx)?;
-
-        self.poll_complete(cx)?;
-
         debug!(
             "send buf: {}, read buf: {}",
             self.write_pending_frames.len(),
@@ -621,6 +617,9 @@ where
             if self.is_dead() {
                 break;
             }
+
+            self.flush(cx)?;
+            self.poll_complete(cx)?;
 
             let mut is_pending = self.control_poll(cx)?.is_pending();
             is_pending &= self.recv_frames(cx)?.is_pending();


### PR DESCRIPTION
ref: #288 

This PR removes the flush command of the stream, because this command and the real message will squeeze each other, and the channel does not need the flush action in the actual sense. This means that the flush operation of the underlying io will be completely executed by the session.

There is no problem originally. Each poll executes a flush, but because the poll has a loop, the flush must be moved into the loop to be completely equivalent to a poll and a flush of other streams.