### PR TITLE
fix: Fix yamux close

### DIFF
--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -56,9 +56,6 @@ env_logger = "0.6.0"
 crossbeam-channel = "0.3.6"
 systemstat = "0.1.3"
 futures-test = "0.3.5"
-## lock on 1.1
-## https://github.com/myrrlyn/funty/issues/3
-funty = "=1.1.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = "0.13.0"

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -239,8 +239,11 @@ where
         let frame = Frame::new_go_away(code);
         self.send_frame(cx, frame)?;
         self.local_go_away = true;
+        let mut new_timer = interval(self.config.connection_write_timeout);
+        // force registration of new timer to driver
+        let _ignore = Pin::new(&mut new_timer).as_mut().poll_next(cx);
         // max wait time for remote go away
-        self.keepalive = Some(interval(self.config.connection_write_timeout));
+        self.keepalive = Some(new_timer);
         Ok(())
     }
 

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -16,7 +16,7 @@ use futures::{
     channel::mpsc::{channel, unbounded, Receiver, Sender, UnboundedReceiver, UnboundedSender},
     Sink, Stream,
 };
-use log::{debug, log_enabled, trace, warn};
+use log::{debug, log_enabled, trace};
 use tokio::prelude::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
@@ -459,7 +459,10 @@ where
                     }
                 } else {
                     // TODO: stream already closed ?
-                    warn!("substream({}) should exist but not", stream_id);
+                    debug!(
+                        "substream({}) should exist but not, may drop by self",
+                        stream_id
+                    );
                     false
                 }
             };

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -449,18 +449,20 @@ impl AsyncWrite for StreamHandle {
 
 impl Drop for StreamHandle {
     fn drop(&mut self) {
-        if !self.unbound_event_sender.is_closed()
-            && self.state != StreamState::Closed
-            && self.state != StreamState::LocalClosing
-        {
-            let mut flags = self.get_flags();
-            flags.add(Flag::Rst);
-            let frame = Frame::new_window_update(flags, self.id, 0);
-            let rst_event = StreamEvent::Frame(frame);
+        if !self.unbound_event_sender.is_closed() && self.state != StreamState::Closed {
             let event = StreamEvent::Closed(self.id);
-            // Always successful unless the session is dropped
-            let _ignore = self.unbound_event_sender.unbounded_send(rst_event);
-            let _ignore = self.unbound_event_sender.unbounded_send(event);
+            if self.state == StreamState::LocalClosing {
+                let _ignore = self.unbound_event_sender.unbounded_send(event);
+            } else {
+                let mut flags = self.get_flags();
+                flags.add(Flag::Rst);
+                let frame = Frame::new_window_update(flags, self.id, 0);
+                let rst_event = StreamEvent::Frame(frame);
+
+                // Always successful unless the session is dropped
+                let _ignore = self.unbound_event_sender.unbounded_send(rst_event);
+                let _ignore = self.unbound_event_sender.unbounded_send(event);
+            }
         }
     }
 }
@@ -565,6 +567,41 @@ mod test {
                 stream.read(&mut b).await.unwrap_err().kind(),
                 ErrorKind::BrokenPipe
             );
+
+            drop(stream);
+            let event = unbound_receiver.next().await.unwrap();
+            match event {
+                StreamEvent::Closed(_) => (),
+                _ => panic!("must be state closed"),
+            }
+        });
+    }
+
+    #[test]
+    fn test_drop_with_state_local_close() {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let (_frame_sender, frame_receiver) = channel(2);
+            let (unbound_sender, mut unbound_receiver) = unbounded();
+            let mut stream = StreamHandle::new(
+                0,
+                unbound_sender,
+                frame_receiver,
+                StreamState::Init,
+                INITIAL_STREAM_WINDOW,
+                INITIAL_STREAM_WINDOW,
+            );
+
+            let _ignore = stream.shutdown().await;
+
+            let event = unbound_receiver.next().await.unwrap();
+            match event {
+                StreamEvent::Frame(frame) => {
+                    assert!(frame.flags().contains(Flag::Fin));
+                    assert_eq!(frame.ty(), Type::WindowUpdate);
+                }
+                _ => panic!("must be fin window update"),
+            }
 
             drop(stream);
             let event = unbound_receiver.next().await.unwrap();

--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -452,6 +452,8 @@ impl Drop for StreamHandle {
         if !self.unbound_event_sender.is_closed() && self.state != StreamState::Closed {
             let event = StreamEvent::Closed(self.id);
             if self.state == StreamState::LocalClosing {
+                // LocalClosing means that local have sent Fin to the remote and waiting for a response.
+                // So, here only need to send a cleanup message
                 let _ignore = self.unbound_event_sender.unbounded_send(event);
             } else {
                 let mut flags = self.get_flags();


### PR DESCRIPTION
1. fix remote does not respond go away

In the current implementation, if the other party does not respond to go away, yamux will wait forever, causing a possible fd attack. Although this is a poorly maintained attack method, during the attack, it must respond to ping/pong messages, otherwise, it will be closed. We cannot be sure whether the remote implementation is fully compliant with the specification. At this time, there must be a shutdown strategy, which is to set a timeout time. When the remote timeout does not respond, the connection will be closed by itself. 

Since yamux needs to be runtime independent, the only thing that can be done here is to instantly replace the ping timer, whether it exists or not, at the same time, due to the inconsistency of timer implementation, it is necessary to force the poll once and register it to the corresponding driver, otherwise, it may cause the problem of not being able to wake up(like this [ci error](https://github.com/nervosnetwork/tentacle/runs/1924048262))

2. fix drop with local close should send event

For stream closing, the normal closing process is:
```
local -- fin ---> remote
remote -- fin ---> local, and remove resources registered in the session
local informs to clean up resources after receiving fin
```
This is a closing process of a streaming connection with a semi-closed feature

The local close state only performed the fin operation sent to the remote and did not perform notification cleanup