### PR TITLE
chore: bump to 0.4.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.4.0-alpha.1
+
+### Features
+- Upgrade tokio to 1.x(#293)
+- Upgrade toolchain to 1.51.0(#315)
+- Change `Multi(Vec<Id>)` to `Filter(Box<Fn(ID) -> bool)`(#312)
+- Introduce `parking_lot` to tentacle priority channel(#316)
+- Support `/Memory/port` to test(#318)
+- Use no hash map to usize key map(#325)
+
 ## 0.3.8
 
 ### Bug Fix

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ fuzz:
 	cargo +nightly fuzz run yamux_frame_codec           -- -max_total_time=60
 
 build:
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features ws
-	$(Change_Work_Path) && RUSTFLAGS='-F warnings' cargo build --all --features ws,unstable
+	$(Change_Work_Path) && RUSTFLAGS='-W warnings' cargo build --all --features ws
+	$(Change_Work_Path) && RUSTFLAGS='-W warnings' cargo build --all --features ws,unstable
 
 examples:
 	$(Change_Work_Path) && cargo build --examples --all --features unstable

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tentacle
 
 [![Build Status](https://travis-ci.com/nervosnetwork/tentacle.svg?branch=master)](https://travis-ci.com/nervosnetwork/tentacle)
-![image](https://img.shields.io/badge/rustc-1.46-blue.svg)
+![image](https://img.shields.io/badge/rustc-1.51-blue.svg)
 
 ## Overview
 

--- a/multiaddr/Cargo.toml
+++ b/multiaddr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-multiaddr"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["driftluo <driftluo@foxmail.com>"]
 edition = "2018"
 

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-secio"
-version = "0.4.5"
+version = "0.5.0"
 license = "MIT"
 description = "Secio encryption protocol for p2p"
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.3.8"
+version = "0.4.0-alpha.1"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -16,8 +16,8 @@ all-features = false
 no-default-features = true
 
 [dependencies]
-yamux = { path = "../yamux", version = "0.2.12", default-features = false, package = "tokio-yamux"}
-secio = { path = "../secio", version = "0.4.5", package = "tentacle-secio" }
+yamux = { path = "../yamux", version = "0.3.0", default-features = false, package = "tokio-yamux"}
+secio = { path = "../secio", version = "0.5.0", package = "tentacle-secio" }
 
 futures = { version = "0.3.0" }
 tokio = { version = "1.0.0" }
@@ -26,7 +26,6 @@ log = "0.4"
 bytes = "1.0.0"
 thiserror = "1.0"
 once_cell = "1.0"
-rand = "0.7"
 nohash-hasher = "0.2"
 
 parking_lot = { version = "0.11", optional = true }
@@ -35,11 +34,15 @@ futures-timer = { version = "3.0.2", optional = true }
 async-std = { version = "1", features = ["unstable"], optional = true }
 async-io = { version = "1", optional = true }
 
-multiaddr = { path = "../multiaddr", package = "tentacle-multiaddr", version = "0.2.0" }
+multiaddr = { path = "../multiaddr", package = "tentacle-multiaddr", version = "0.3.0" }
 molecule = "0.7.0"
 
 # upnp
 igd = { version = "0.11", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# rand 0.8 not support wasm32
+rand = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
@@ -64,7 +67,7 @@ futures-test = "0.3.5"
 nix = "0.13.0"
 
 [features]
-default = ["tokio-runtime", "tokio-timer", "upnp"]
+default = ["tokio-runtime", "tokio-timer"]
 ws = ["tokio-tungstenite"]
 upnp = ["igd"]
 unstable = []

--- a/tentacle/README.md
+++ b/tentacle/README.md
@@ -1,7 +1,7 @@
 # Tentacle
 
 [![Build Status](https://api.travis-ci.org/nervosnetwork/tentacle.svg?branch=master)](https://travis-ci.org/nervosnetwork/tentacle)
-![image](https://img.shields.io/badge/rustc-1.46-blue.svg)
+![image](https://img.shields.io/badge/rustc-1.51-blue.svg)
 
 ## Overview
 

--- a/tentacle/src/lib.rs
+++ b/tentacle/src/lib.rs
@@ -69,6 +69,25 @@
 //! 6. Run [`Service`] just like other stream, maybe keep a [`Control`] on some place which want to
 //!    communicate with background [`Service`]
 //!
+//! ### Feature flags
+//! Tentacle uses the Feature flag to enable some optional functions and split the smallest dependencies
+//! for use as much as possible. Users can choose the dependencies they want according to their needs.
+//!
+//! Related to runtime :
+//! - `tokio-runtime`: Enable by default, use tokio runtime
+//! - `tokio-timer`: Enable by default, use tokio inner timer
+//!
+//! - `async-timer`: use async-io timer
+//! - `async-runtime`: use async-std runtime
+//!
+//! - `generic-timer`: use futures-timer
+//! - `wasm-timer`: only use on Browser WebAssembly platform
+//!
+//! Function related:
+//! - `ws`: Enable websocket protocol support
+//! - `upnp`: Enable upnp protocol, automatically try to register the port to the gateway
+//! - `unstable`: Enable the feature that has not yet decided to stabilize the API
+//! - `parking_lot`: Enable priority channel use `parking_lot`
 //!
 //! [`MetaBuilder`]: crate::builder::MetaBuilder
 //! [`ServiceBuilder`]: crate::builder::ServiceBuilder
@@ -123,7 +142,8 @@ pub(crate) mod transports;
 pub mod utils;
 
 mod channel;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "unstable"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod runtime;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "upnp"))]

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-yamux"
-version = "0.2.12"
+version = "0.3.0"
 license = "MIT"
 repository = "https://github.com/nervosnetwork/tentacle"
 description = "Rust implementation of Yamux"


### PR DESCRIPTION
wait for #318 

This version is to allow users to transition to the tokio 1.0 era and then will begin async trait, which will be a very big break change, so the alpha version will be released first. When the async trait is implemented, the 0.4.0 version will be released. 