### PR TITLE
feat: use async trait

### DIFF
--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -114,11 +114,7 @@ pub fn init() {
                     .await
                     .unwrap();
                 let _res = addr_sender.send(listen_addr);
-                loop {
-                    if service.run().await.is_none() {
-                        break;
-                    }
-                }
+                service.run().await
             });
         });
 
@@ -133,11 +129,7 @@ pub fn init() {
                     .dial(listen_addr, TargetProtocol::All)
                     .await
                     .unwrap();
-                loop {
-                    if service.run().await.is_none() {
-                        break;
-                    }
-                }
+                service.run().await
             });
         });
 
@@ -162,11 +154,7 @@ pub fn init() {
                     .await
                     .unwrap();
                 let _res = addr_sender.send(listen_addr);
-                loop {
-                    if service.run().await.is_none() {
-                        break;
-                    }
-                }
+                service.run().await
             });
         });
 
@@ -181,11 +169,7 @@ pub fn init() {
                     .dial(listen_addr, TargetProtocol::All)
                     .await
                     .unwrap();
-                loop {
-                    if service.run().await.is_none() {
-                        break;
-                    }
-                }
+                service.run().await
             });
         });
 

--- a/simple_wasm/src/simple.rs
+++ b/simple_wasm/src/simple.rs
@@ -127,10 +127,6 @@ pub fn client() {
             )
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }

--- a/simple_wasm/src/simple.rs
+++ b/simple_wasm/src/simple.rs
@@ -1,4 +1,3 @@
-use futures::prelude::*;
 use log::{error, info};
 use std::{str, time::Duration};
 use tentacle::{
@@ -11,7 +10,7 @@ use tentacle::{
         TargetSession,
     },
     traits::{ServiceHandle, ServiceProtocol},
-    ProtocolId, SessionId,
+    ProtocolId, SessionId, async_trait
 };
 
 fn create_meta(id: ProtocolId) -> ProtocolMeta {
@@ -35,14 +34,15 @@ struct PHandle {
     connected_session_ids: Vec<SessionId>,
 }
 
+#[async_trait(?Send)]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, context: &mut ProtocolContext) {
+    async fn init(&mut self, context: &mut ProtocolContext) {
         if context.proto_id == 0.into() {
-            let _ = context.set_service_notify(0.into(), Duration::from_secs(5), 3);
+            let _ = context.set_service_notify(0.into(), Duration::from_secs(5), 3).await;
         }
     }
 
-    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
         let session = context.session;
         self.connected_session_ids.push(session.id);
         info!(
@@ -51,7 +51,7 @@ impl ServiceProtocol for PHandle {
         );
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
         let new_list = self
             .connected_session_ids
             .iter()
@@ -66,7 +66,7 @@ impl ServiceProtocol for PHandle {
         );
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
         self.count += 1;
         info!(
             "received from [{}]: proto [{}] data {:?}, message count: {}",
@@ -77,7 +77,7 @@ impl ServiceProtocol for PHandle {
         );
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
         info!(
             "proto [{}] received notify token: {}",
             context.proto_id, token
@@ -87,17 +87,18 @@ impl ServiceProtocol for PHandle {
             TargetSession::All,
             1.into(),
             Bytes::from("I am a interval message"),
-        );
+        ).await;
     }
 }
 
 struct SHandle;
 
+#[async_trait(?Send)]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
         error!("service error: {:?}", error);
     }
-    fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
         info!("service event: {:?}", event);
     }
 }
@@ -127,7 +128,7 @@ pub fn client() {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 features = [ "tokio-runtime", "tokio-timer", "upnp", "ws", "unstable", "tls" ]
 all-features = false
 no-default-features = true
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 yamux = { path = "../yamux", version = "0.3.0", default-features = false, package = "tokio-yamux"}

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -20,8 +20,9 @@ yamux = { path = "../yamux", version = "0.3.0", default-features = false, packag
 secio = { path = "../secio", version = "0.5.0", package = "tentacle-secio" }
 
 futures = { version = "0.3.0" }
-tokio = { version = "1.0.0" }
+tokio = { version = "1.0.0", features = ["macros"] }
 tokio-util = { version = "0.6.0", features = ["codec"] }
+async-trait = "0.1"
 log = "0.4"
 bytes = "1.0.0"
 thiserror = "1.0"

--- a/tentacle/examples/block_send.rs
+++ b/tentacle/examples/block_send.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
-use futures::StreamExt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     secio::SecioKeyPair,
@@ -32,35 +32,40 @@ struct PHandle {
     count: Arc<AtomicUsize>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "abcde".repeat(800);
             // NOTE: 256 is the send channel buffer size
             let length = 1024;
             for i in 0..length {
                 println!("> [Server] send {}", i);
-                let _ = context.send_message(Bytes::from(format!(
-                    "{}-000000000000000000000{}",
-                    prefix, i
-                )));
+                let _ = context
+                    .send_message(Bytes::from(format!(
+                        "{}-000000000000000000000{}",
+                        prefix, i
+                    )))
+                    .await;
             }
         }
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: Bytes) {
         let count_now = self.count.load(Ordering::SeqCst);
         if context.session.ty.is_outbound() {
             println!("> [Client] received {}", count_now);
-            let _ = context.send_message(format!("xx-{}", count_now).into());
+            let _ = context
+                .send_message(format!("xx-{}", count_now).into())
+                .await;
             self.count.fetch_add(1, Ordering::SeqCst);
         } else {
             println!("> [Server] received {}", String::from_utf8_lossy(&data));
         }
         if count_now + 1 == 1024 {
-            let _ = context.close();
+            let _ = context.close().await;
         }
     }
 }
@@ -98,7 +103,7 @@ fn main() {
                 .unwrap();
             println!("listen_addr: {}", listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -113,7 +118,7 @@ fn main() {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/examples/block_send.rs
+++ b/tentacle/examples/block_send.rs
@@ -102,11 +102,7 @@ fn main() {
                 .await
                 .unwrap();
             println!("listen_addr: {}", listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     } else {
         rt.block_on(async move {
@@ -117,11 +113,7 @@ fn main() {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     }
 }

--- a/tentacle/examples/heavy_task_schedule.rs
+++ b/tentacle/examples/heavy_task_schedule.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
-use futures::StreamExt;
 use log::info;
 use std::collections::HashMap;
 use std::thread;
 use std::time::{Duration, Instant};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     secio::SecioKeyPair,
@@ -21,14 +21,19 @@ struct PHandle {
     count: usize,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, context: &mut ProtocolContext) {
+    async fn init(&mut self, context: &mut ProtocolContext) {
         let proto_id = context.proto_id;
-        let _ = context.set_service_notify(proto_id, Duration::from_millis(10), 0);
-        let _ = context.set_service_notify(proto_id, Duration::from_millis(40), 1);
+        let _ = context
+            .set_service_notify(proto_id, Duration::from_millis(10), 0)
+            .await;
+        let _ = context
+            .set_service_notify(proto_id, Duration::from_millis(40), 1)
+            .await;
     }
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         info!(
             "Session open: {:?} {}",
             context.session.id, context.session.address
@@ -36,7 +41,7 @@ impl ServiceProtocol for PHandle {
         self.sessions.insert(context.session.id, context.session.ty);
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
         log::warn!(
             "Session close: {:?} {}",
             context.session.id,
@@ -45,7 +50,7 @@ impl ServiceProtocol for PHandle {
         self.sessions.remove(&context.session.id);
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: Bytes) {
         let session_type = context.session.ty;
         let session_id = context.session.id;
         if session_type.is_outbound() {
@@ -53,7 +58,7 @@ impl ServiceProtocol for PHandle {
             info!("> [Client] received {}", self.count);
             self.count += 1;
             if self.count + 1 == 512 {
-                let _ = context.shutdown();
+                let _ = context.shutdown().await;
             }
         } else {
             // thread::sleep(Duration::from_millis(20));
@@ -61,7 +66,7 @@ impl ServiceProtocol for PHandle {
         }
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
         let proto_id = context.proto_id;
         match token {
             0 => {
@@ -75,7 +80,7 @@ impl ServiceProtocol for PHandle {
                     let prefix = "abcde".repeat(80000);
                     let now = Instant::now();
                     let data = Bytes::from(format!("{:?} - {}", now, prefix));
-                    let _ = context.send_message_to(*session_id, proto_id, data);
+                    let _ = context.send_message_to(*session_id, proto_id, data).await;
                 }
             }
             1 => {
@@ -89,7 +94,7 @@ impl ServiceProtocol for PHandle {
                     let prefix = "xxxx".repeat(20000);
                     let now = Instant::now();
                     let data = Bytes::from(format!("{:?} - {}", now, prefix));
-                    let _ = context.send_message_to(*session_id, proto_id, data);
+                    let _ = context.send_message_to(*session_id, proto_id, data).await;
                 }
             }
             _ => {}
@@ -99,11 +104,12 @@ impl ServiceProtocol for PHandle {
 
 struct SHandle;
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
         info!("service error: {:?}", error);
     }
-    fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
         info!("service event: {:?}", event);
     }
 }
@@ -154,7 +160,7 @@ fn main() {
                 .unwrap();
             info!("listen_addr: {}", listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -169,7 +175,7 @@ fn main() {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/examples/heavy_task_schedule.rs
+++ b/tentacle/examples/heavy_task_schedule.rs
@@ -159,11 +159,7 @@ fn main() {
                 .await
                 .unwrap();
             info!("listen_addr: {}", listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     } else {
         rt.block_on(async move {
@@ -174,11 +170,7 @@ fn main() {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     }
 }

--- a/tentacle/examples/simple.rs
+++ b/tentacle/examples/simple.rs
@@ -219,11 +219,7 @@ fn server() {
             .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }
 
@@ -239,10 +235,6 @@ fn client() {
             )
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }

--- a/tentacle/examples/simple.rs
+++ b/tentacle/examples/simple.rs
@@ -9,6 +9,7 @@ use log::info;
 use std::collections::HashMap;
 use std::{str, time::Duration};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     secio::SecioKeyPair,
@@ -45,14 +46,17 @@ struct PHandle {
     clear_handle: HashMap<SessionId, Sender<()>>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, context: &mut ProtocolContext) {
+    async fn init(&mut self, context: &mut ProtocolContext) {
         if context.proto_id == 0.into() {
-            let _ = context.set_service_notify(0.into(), Duration::from_secs(5), 3);
+            let _ = context
+                .set_service_notify(0.into(), Duration::from_secs(5), 3)
+                .await;
         }
     }
 
-    fn connected(&mut self, context: ProtocolContextMutRef, version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
         let session = context.session;
         self.connected_session_ids.push(session.id);
         info!(
@@ -77,22 +81,22 @@ impl ServiceProtocol for PHandle {
                 tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
             loop {
                 interval.tick().await;
-                let _ = interval_sender.send_message_to(
-                    session_id,
-                    1.into(),
-                    Bytes::from("I am a interval message"),
-                );
+                let _ = interval_sender
+                    .send_message_to(session_id, 1.into(), Bytes::from("I am a interval message"))
+                    .await;
             }
         };
 
         let task = select(receiver, interval_send_task.boxed());
 
-        let _ = context.future_task(async move {
-            task.await;
-        });
+        let _ = context
+            .future_task(async move {
+                task.await;
+            })
+            .await;
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
         let new_list = self
             .connected_session_ids
             .iter()
@@ -111,7 +115,7 @@ impl ServiceProtocol for PHandle {
         );
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
         self.count += 1;
         info!(
             "received from [{}]: proto [{}] data {:?}, message count: {}",
@@ -122,7 +126,7 @@ impl ServiceProtocol for PHandle {
         );
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
         info!(
             "proto [{}] received notify token: {}",
             context.proto_id, token
@@ -132,26 +136,31 @@ impl ServiceProtocol for PHandle {
 
 struct SHandle;
 
+#[async_trait]
 impl ServiceHandle for SHandle {
     // A lot of internal error events will be output here, but not all errors need to close the service,
     // some just tell users that they need to pay attention
-    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
         info!("service error: {:?}", error);
     }
-    fn handle_event(&mut self, context: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, context: &mut ServiceContext, event: ServiceEvent) {
         info!("service event: {:?}", event);
         if let ServiceEvent::SessionOpen { .. } = event {
             let delay_sender = context.control().clone();
 
-            let _ = context.future_task(async move {
-                tokio::time::sleep_until(tokio::time::Instant::now() + Duration::from_secs(3))
-                    .await;
-                let _ = delay_sender.filter_broadcast(
-                    TargetSession::All,
-                    0.into(),
-                    Bytes::from("I am a delayed message"),
-                );
-            });
+            let _ = context
+                .future_task(async move {
+                    tokio::time::sleep_until(tokio::time::Instant::now() + Duration::from_secs(3))
+                        .await;
+                    let _ = delay_sender
+                        .filter_broadcast(
+                            TargetSession::All,
+                            0.into(),
+                            Bytes::from("I am a delayed message"),
+                        )
+                        .await;
+                })
+                .await;
         }
     }
 }
@@ -211,7 +220,7 @@ fn server() {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }
@@ -231,7 +240,7 @@ fn client() {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/examples/simple_using_spawn.rs
+++ b/tentacle/examples/simple_using_spawn.rs
@@ -7,12 +7,13 @@ use futures::StreamExt;
 use log::info;
 use std::{str, sync::Arc, time::Duration};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ServiceContext, SessionContext},
     secio::SecioKeyPair,
     service::{
-        ProtocolMeta, Service, ServiceAsyncControl, ServiceControl, ServiceError, ServiceEvent,
-        TargetProtocol, TargetSession,
+        ProtocolMeta, Service, ServiceAsyncControl, ServiceError, ServiceEvent, TargetProtocol,
+        TargetSession,
     },
     traits::{ProtocolSpawn, ServiceHandle},
     ProtocolId, SubstreamReadPart,
@@ -24,10 +25,10 @@ impl ProtocolSpawn for ProtocolStream {
     fn spawn(
         &self,
         context: Arc<SessionContext>,
-        control: &ServiceControl,
+        control: &ServiceAsyncControl,
         mut read_part: SubstreamReadPart,
     ) {
-        let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+        let control = control.clone();
         tokio::spawn(async move {
             info!(
                 "{}, {:?}, {}, opened",
@@ -36,7 +37,7 @@ impl ProtocolSpawn for ProtocolStream {
                 read_part.protocol_id()
             );
             if read_part.protocol_id() == 1.into() {
-                let mut c = control.clone();
+                let c = control.clone();
                 let pid = read_part.protocol_id();
                 let mut interval =
                     tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
@@ -88,24 +89,27 @@ fn create_meta(id: ProtocolId) -> ProtocolMeta {
 
 struct SHandle;
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
         info!("service error: {:?}", error);
     }
-    fn handle_event(&mut self, context: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, context: &mut ServiceContext, event: ServiceEvent) {
         info!("service event: {:?}", event);
         if let ServiceEvent::SessionOpen { .. } = event {
             let delay_sender = context.control().clone();
 
-            let _ = context.future_task(async move {
-                tokio::time::sleep_until(tokio::time::Instant::now() + Duration::from_secs(3))
-                    .await;
-                let _ = delay_sender.filter_broadcast(
-                    TargetSession::All,
-                    0.into(),
-                    Bytes::from("I am a delayed message"),
-                );
-            });
+            let _ = context
+                .future_task(async move {
+                    tokio::time::sleep_until(tokio::time::Instant::now() + Duration::from_secs(3))
+                        .await;
+                    let _ = delay_sender.filter_broadcast(
+                        TargetSession::All,
+                        0.into(),
+                        Bytes::from("I am a delayed message"),
+                    );
+                })
+                .await;
         }
     }
 }
@@ -158,7 +162,7 @@ fn server() {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }
@@ -178,7 +182,7 @@ fn client() {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/examples/simple_using_spawn.rs
+++ b/tentacle/examples/simple_using_spawn.rs
@@ -161,11 +161,7 @@ fn server() {
             .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }
 
@@ -181,10 +177,6 @@ fn client() {
             )
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }

--- a/tentacle/examples/use_poll.rs
+++ b/tentacle/examples/use_poll.rs
@@ -89,10 +89,6 @@ fn run() {
                 tx.send(()).await.unwrap();
             }
         });
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }

--- a/tentacle/examples/use_poll.rs
+++ b/tentacle/examples/use_poll.rs
@@ -1,4 +1,5 @@
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ServiceContext},
     secio::SecioKeyPair,
@@ -13,11 +14,7 @@ use futures::{
     StreamExt,
 };
 use log::info;
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::time::Duration;
 
 /// This example is used to illustrate how to implement the poll interface
 /// and use it for inner loop notification
@@ -28,11 +25,12 @@ fn main() {
 
 struct SHandle;
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _context: &mut ServiceContext, error: ServiceError) {
         info!("service error: {:?}", error);
     }
-    fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, _context: &mut ServiceContext, event: ServiceEvent) {
         info!("service event: {:?}", event);
     }
 }
@@ -41,21 +39,17 @@ struct PHandle {
     poll_recv: Receiver<()>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context,
-        _context: &mut ProtocolContext,
-    ) -> Poll<Option<()>> {
-        match self.poll_recv.poll_next_unpin(cx) {
-            Poll::Ready(Some(_)) => {
+    async fn poll(&mut self, _context: &mut ProtocolContext) -> Option<()> {
+        match self.poll_recv.next().await {
+            Some(_) => {
                 info!("get a trick");
-                Poll::Ready(Some(()))
+                Some(())
             }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            None => None,
         }
     }
 }
@@ -96,7 +90,7 @@ fn run() {
             }
         });
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/src/buffer.rs
+++ b/tentacle/src/buffer.rs
@@ -174,10 +174,6 @@ impl<T> Buffer<T> {
         (self.sender.clone(), ::std::mem::take(&mut self.buffer))
     }
 
-    pub fn clone_sender(&self) -> Sender<T> {
-        self.sender.clone()
-    }
-
     pub fn clear(&mut self) {
         self.buffer.clear()
     }

--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -9,7 +9,7 @@ use crate::{
     protocol_select::SelectFn,
     secio::SecioKeyPair,
     service::{
-        config::{BlockingFlag, Meta, ServiceConfig},
+        config::{Meta, ServiceConfig},
         ProtocolHandle, ProtocolMeta, Service,
     },
     traits::{Codec, ProtocolSpawn, ServiceHandle, ServiceProtocol, SessionProtocol},
@@ -202,7 +202,6 @@ pub struct MetaBuilder {
     select_version: SelectVersionFn,
     before_send: Option<Box<dyn Fn(bytes::Bytes) -> bytes::Bytes + Send + 'static>>,
     before_receive: BeforeReceiveFn,
-    flag: BlockingFlag,
     spawn: Option<Box<dyn ProtocolSpawn + Send + Sync + 'static>>,
 }
 
@@ -313,12 +312,6 @@ impl MetaBuilder {
         self
     }
 
-    /// Set a flag to control function behavior
-    pub fn flag(mut self, flag: BlockingFlag) -> Self {
-        self.flag = flag;
-        self
-    }
-
     /// Combine the configuration of this builder to create a ProtocolMeta
     pub fn build(mut self) -> ProtocolMeta {
         if self.spawn.is_some() {
@@ -339,7 +332,6 @@ impl MetaBuilder {
             service_handle: self.service_handle,
             session_handle: self.session_handle,
             before_send: self.before_send,
-            flag: self.flag,
         }
     }
 }
@@ -356,7 +348,6 @@ impl Default for MetaBuilder {
             select_version: Box::new(|| None),
             before_send: None,
             before_receive: Box::new(|| None),
-            flag: BlockingFlag::default(),
             spawn: None,
         }
     }

--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -124,6 +124,7 @@ impl ServiceBuilder {
     /// receive the access request of the external network, and if the external ip of the route is not the public network,
     /// Then do nothing
     #[cfg(all(not(target_arch = "wasm32"), feature = "upnp"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "upnp")))]
     pub fn upnp(mut self, enable: bool) -> Self {
         self.config.upnp = enable;
         self
@@ -153,6 +154,7 @@ impl ServiceBuilder {
 
     /// The same as tcp bind, but use on ws transport
     #[cfg(feature = "ws")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
     pub fn ws_bind(mut self, addr: multiaddr::Multiaddr) -> Self {
         self.config.ws_bind_addr = multiaddr_to_socketaddr(&addr);
         self
@@ -280,6 +282,7 @@ impl MetaBuilder {
     ///
     /// Mutually exclusive with protocol handle
     #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub fn protocol_spawn<T: ProtocolSpawn + Send + Sync + 'static>(mut self, spawn: T) -> Self {
         self.spawn = Some(Box::new(spawn));
         self

--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -167,6 +167,7 @@ impl ServiceBuilder {
 
     /// set rustls ServerConfig, default is NoClientAuth
     #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub fn tls_config(mut self, config: TlsConfig) -> Self {
         self.config.tls_config = Some(config);
         self

--- a/tentacle/src/error.rs
+++ b/tentacle/src/error.rs
@@ -24,9 +24,6 @@ pub enum TransportErrorKind {
 #[derive(Error, Debug)]
 /// Protocol handle error
 pub enum ProtocolHandleErrorKind {
-    /// protocol handle block, may be user's protocol handle implementation problem
-    #[error("protocol handle block, session id: `{0:?}`")]
-    Block(Option<SessionId>),
     /// protocol handle abnormally closed, may be user's protocol handle implementation problem
     #[error("protocol handle abnormally closed, session id: `{0:?}`")]
     AbnormallyClosed(Option<SessionId>),

--- a/tentacle/src/lib.rs
+++ b/tentacle/src/lib.rs
@@ -107,6 +107,8 @@
     allow(dead_code, unused_variables, unused_imports)
 )]
 
+/// Re-pub async trait
+pub use async_trait::async_trait;
 /// Re-pub bytes crate
 pub use bytes;
 /// Re-pub multiaddr crate

--- a/tentacle/src/lib.rs
+++ b/tentacle/src/lib.rs
@@ -106,6 +106,7 @@
     target_arch = "wasm32",
     allow(dead_code, unused_variables, unused_imports)
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Re-pub async trait
 pub use async_trait::async_trait;
@@ -146,6 +147,7 @@ pub mod utils;
 
 mod channel;
 #[cfg_attr(not(feature = "unstable"), doc(hidden))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 #[allow(missing_docs)]
 pub mod runtime;
 

--- a/tentacle/src/protocol_handle_stream.rs
+++ b/tentacle/src/protocol_handle_stream.rs
@@ -1,14 +1,12 @@
-use futures::{channel::mpsc, SinkExt, Stream};
+use futures::{channel::mpsc, SinkExt, StreamExt};
 use log::{debug, trace};
 use nohash_hasher::IntMap;
 use std::collections::HashMap;
 use std::{
-    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    task::{Context, Poll},
     time::Duration,
 };
 
@@ -16,23 +14,11 @@ use crate::{
     context::{ProtocolContext, ServiceContext, SessionContext},
     error::ProtocolHandleErrorKind,
     multiaddr::Multiaddr,
-    service::{config::BlockingFlag, future_task::BoxedFutureTask},
+    service::future_task::BoxedFutureTask,
     session::SessionEvent,
     traits::{ServiceProtocol, SessionProtocol},
     ProtocolId, SessionId,
 };
-
-#[inline]
-fn block_in_place<F, R>(flag: bool, f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    if flag {
-        crate::runtime::block_in_place(f)
-    } else {
-        f()
-    }
-}
 
 #[derive(Clone)]
 pub enum ServiceProtocolEvent {
@@ -100,8 +86,6 @@ pub struct ServiceProtocolStream<T> {
     current_task: CurrentTask,
     shutdown: Arc<AtomicBool>,
     future_task_sender: mpsc::Sender<BoxedFutureTask>,
-    flag: BlockingFlag,
-    need_poll: bool,
 }
 
 impl<T> ServiceProtocolStream<T>
@@ -112,7 +96,7 @@ where
         handle: T,
         service_context: ServiceContext,
         receiver: mpsc::Receiver<ServiceProtocolEvent>,
-        (proto_id, flag): (ProtocolId, BlockingFlag),
+        proto_id: ProtocolId,
         panic_report: mpsc::Sender<SessionEvent>,
         (shutdown, future_task_sender): (Arc<AtomicBool>, mpsc::Sender<BoxedFutureTask>),
     ) -> Self {
@@ -129,13 +113,11 @@ where
             shutdown,
             panic_report,
             future_task_sender,
-            flag,
-            need_poll: true,
         }
     }
 
     #[inline]
-    pub fn handle_event(&mut self, event: ServiceProtocolEvent) {
+    pub async fn handle_event(&mut self, event: ServiceProtocolEvent) {
         use self::ServiceProtocolEvent::*;
 
         let shutdown = self.shutdown.load(Ordering::SeqCst);
@@ -158,30 +140,29 @@ where
         for session_id in closed_sessions {
             if let Some(session) = self.sessions.remove(&session_id) {
                 self.handle
-                    .disconnected(self.handle_context.as_mut(&session));
+                    .disconnected(self.handle_context.as_mut(&session))
+                    .await;
             }
         }
 
         match event {
             Init => {
                 self.current_task.run();
-                self.handle.init(&mut self.handle_context)
+                self.handle.init(&mut self.handle_context).await
             }
             Connected { session, version } => {
                 self.current_task.run_with_id(session.id);
-                block_in_place(self.flag.connected(), || {
-                    self.handle
-                        .connected(self.handle_context.as_mut(&session), &version)
-                });
+                self.handle
+                    .connected(self.handle_context.as_mut(&session), &version)
+                    .await;
                 self.sessions.insert(session.id, session);
             }
             Disconnected { id } => {
                 self.current_task.run_with_id(id);
                 if let Some(session) = self.sessions.remove(&id) {
-                    block_in_place(self.flag.disconnected(), || {
-                        self.handle
-                            .disconnected(self.handle_context.as_mut(&session))
-                    })
+                    self.handle
+                        .disconnected(self.handle_context.as_mut(&session))
+                        .await
                 }
             }
             Received { id, data } => {
@@ -190,18 +171,15 @@ where
                     if !session.closed.load(Ordering::SeqCst)
                         && !self.shutdown.load(Ordering::SeqCst)
                     {
-                        block_in_place(self.flag.received(), || {
-                            self.handle
-                                .received(self.handle_context.as_mut(&session), data)
-                        });
+                        self.handle
+                            .received(self.handle_context.as_mut(&session), data)
+                            .await
                     }
                 }
             }
             Notify { token } => {
                 self.current_task.run();
-                block_in_place(self.flag.notify(), || {
-                    self.handle.notify(&mut self.handle_context, token)
-                });
+                self.handle.notify(&mut self.handle_context, token).await;
                 self.set_notify(token);
             }
             SetNotify { interval, token } => {
@@ -221,17 +199,6 @@ where
         self.current_task.idle();
     }
 
-    fn handle_poll(&mut self, cx: &mut Context) -> bool {
-        match Pin::new(&mut self.handle).poll(cx, &mut self.handle_context) {
-            Poll::Ready(None) => {
-                self.need_poll = false;
-                true
-            }
-            Poll::Ready(Some(())) => false,
-            Poll::Pending => true,
-        }
-    }
-
     fn set_notify(&mut self, token: u64) {
         if let Some(&interval) = self.notify.get(&token) {
             let mut sender = self.notify_sender.clone();
@@ -249,6 +216,37 @@ where
                     trace!("service notify task send err")
                 }
             });
+        }
+    }
+
+    pub async fn run(&mut self) {
+        loop {
+            if self.shutdown.load(Ordering::SeqCst) {
+                debug!(
+                    "ServiceProtocolStream({:?}) finished, shutdown",
+                    self.handle_context.proto_id
+                );
+                self.current_task.idle();
+                break;
+            }
+            tokio::select! {
+                event = self.receiver.next() => {
+                    match event {
+                        Some(event) => self.handle_event(event).await,
+                        None => {
+                            self.current_task.idle();
+                            break
+                        }
+                    }
+                },
+                token = self.notify_receiver.next()  => {
+                    if let Some(token) = token {
+                        self.handle_event(ServiceProtocolEvent::Notify { token }).await;
+                    }
+                },
+                Some(_) = &mut self.handle.poll(&mut self.handle_context) => {},
+                else => break
+            }
         }
     }
 }
@@ -275,68 +273,6 @@ impl<T> Drop for ServiceProtocolStream<T> {
                     }
                 });
             }
-        }
-    }
-}
-
-impl<T> Stream for ServiceProtocolStream<T>
-where
-    T: ServiceProtocol + Send + Unpin,
-{
-    type Item = ();
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if self.shutdown.load(Ordering::SeqCst) {
-            debug!(
-                "ServiceProtocolStream({:?}) finished, shutdown",
-                self.handle_context.proto_id
-            );
-            self.current_task.idle();
-            return Poll::Ready(None);
-        }
-
-        let mut is_pending = match Pin::new(&mut self.receiver).as_mut().poll_next(cx) {
-            Poll::Ready(Some(event)) => {
-                self.handle_event(event);
-                false
-            }
-            Poll::Ready(None) => {
-                debug!(
-                    "ServiceProtocolStream({:?}) finished",
-                    self.handle_context.proto_id
-                );
-                self.current_task.idle();
-                return Poll::Ready(None);
-            }
-            Poll::Pending => true,
-        };
-
-        match Pin::new(&mut self.notify_receiver).as_mut().poll_next(cx) {
-            Poll::Ready(Some(token)) => {
-                self.handle_event(ServiceProtocolEvent::Notify { token });
-                is_pending &= false
-            }
-            Poll::Ready(None) => unreachable!(),
-            Poll::Pending => is_pending &= true,
-        }
-
-        if self.need_poll {
-            is_pending &= self.handle_poll(cx);
-        }
-
-        if self.shutdown.load(Ordering::SeqCst) {
-            debug!(
-                "ServiceProtocolStream({:?}) finished, shutdown",
-                self.handle_context.proto_id
-            );
-            self.current_task.idle();
-            return Poll::Ready(None);
-        }
-
-        if is_pending {
-            Poll::Pending
-        } else {
-            Poll::Ready(Some(()))
         }
     }
 }
@@ -383,8 +319,6 @@ pub struct SessionProtocolStream<T> {
     panic_report: mpsc::Sender<SessionEvent>,
     shutdown: Arc<AtomicBool>,
     future_task_sender: mpsc::Sender<BoxedFutureTask>,
-    flag: BlockingFlag,
-    need_poll: bool,
 }
 
 impl<T> SessionProtocolStream<T>
@@ -396,7 +330,7 @@ where
         service_context: ServiceContext,
         context: Arc<SessionContext>,
         receiver: mpsc::Receiver<SessionProtocolEvent>,
-        (proto_id, flag): (ProtocolId, BlockingFlag),
+        proto_id: ProtocolId,
         panic_report: mpsc::Sender<SessionEvent>,
         (shutdown, future_task_sender): (Arc<AtomicBool>, mpsc::Sender<BoxedFutureTask>),
     ) -> Self {
@@ -413,13 +347,11 @@ where
             current_task: false,
             shutdown,
             future_task_sender,
-            flag,
-            need_poll: true,
         }
     }
 
     #[inline]
-    fn handle_event(&mut self, mut event: SessionProtocolEvent) {
+    async fn handle_event(&mut self, mut event: SessionProtocolEvent) {
         use self::SessionProtocolEvent::*;
 
         self.current_task = true;
@@ -439,28 +371,28 @@ where
         }
 
         match event {
-            Opened { version } => block_in_place(self.flag.connected(), || {
+            Opened { version } => {
                 self.handle
                     .connected(self.handle_context.as_mut(&self.context), &version)
-            }),
+                    .await
+            }
             Closed => {
-                block_in_place(self.flag.disconnected(), || {
-                    self.handle
-                        .disconnected(self.handle_context.as_mut(&self.context))
-                });
+                self.handle
+                    .disconnected(self.handle_context.as_mut(&self.context))
+                    .await
             }
             Disconnected => {
                 self.close();
             }
-            Received { data } => block_in_place(self.flag.received(), || {
+            Received { data } => {
                 self.handle
                     .received(self.handle_context.as_mut(&self.context), data)
-            }),
+                    .await
+            }
             Notify { token } => {
-                block_in_place(self.flag.notify(), || {
-                    self.handle
-                        .notify(self.handle_context.as_mut(&self.context), token)
-                });
+                self.handle
+                    .notify(self.handle_context.as_mut(&self.context), token)
+                    .await;
                 self.set_notify(token);
             }
             SetNotify { token, interval } => {
@@ -475,17 +407,6 @@ where
             }
         }
         self.current_task = false;
-    }
-
-    fn handle_poll(&mut self, cx: &mut Context) -> bool {
-        match Pin::new(&mut self.handle).poll(cx, self.handle_context.as_mut(&self.context)) {
-            Poll::Ready(None) => {
-                self.need_poll = false;
-                true
-            }
-            Poll::Ready(Some(())) => false,
-            Poll::Pending => true,
-        }
     }
 
     fn set_notify(&mut self, token: u64) {
@@ -513,6 +434,29 @@ where
         self.receiver.close();
         self.current_task = false;
     }
+
+    pub async fn run(&mut self) {
+        loop {
+            tokio::select! {
+                event = self.receiver.next() => {
+                    match event {
+                        Some(event) => self.handle_event(event).await,
+                        None => {
+                            self.close();
+                            break
+                        }
+                    }
+                }
+                token = self.notify_receiver.next() => {
+                    if let Some(token) = token {
+                        self.handle_event(SessionProtocolEvent::Notify { token }).await;
+                    }
+                }
+                Some(_) = self.handle.poll(self.handle_context.as_mut(&self.context)) => {},
+                else => break
+            }
+        }
+    }
 }
 
 impl<T> Drop for SessionProtocolStream<T> {
@@ -528,46 +472,6 @@ impl<T> Drop for SessionProtocolStream<T> {
                     trace!("session panic message send err")
                 }
             });
-        }
-    }
-}
-
-impl<T> Stream for SessionProtocolStream<T>
-where
-    T: SessionProtocol + Send + Unpin,
-{
-    type Item = ();
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let mut is_pending = match Pin::new(&mut self.receiver).as_mut().poll_next(cx) {
-            Poll::Ready(Some(event)) => {
-                self.handle_event(event);
-                false
-            }
-            Poll::Ready(None) => {
-                self.close();
-                return Poll::Ready(None);
-            }
-            Poll::Pending => true,
-        };
-
-        match Pin::new(&mut self.notify_receiver).as_mut().poll_next(cx) {
-            Poll::Ready(Some(token)) => {
-                self.handle_event(SessionProtocolEvent::Notify { token });
-                is_pending &= false
-            }
-            Poll::Ready(None) => unreachable!(),
-            Poll::Pending => is_pending &= true,
-        }
-
-        if self.need_poll {
-            is_pending &= self.handle_poll(cx);
-        }
-
-        if is_pending {
-            Poll::Pending
-        } else {
-            Poll::Ready(Some(()))
         }
     }
 }

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -1,26 +1,20 @@
-use futures::{
-    channel::mpsc,
-    prelude::*,
-    stream::{FusedStream, StreamExt},
-};
-use log::{debug, error, log_enabled, trace, warn};
 use nohash_hasher::IntMap;
+use futures::{channel::mpsc, prelude::*, stream::StreamExt};
+use log::{debug, error, trace};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
-    task::{Context, Poll},
 };
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::service::helper::Listener;
 use crate::{
-    buffer::{Buffer, SendResult},
+    buffer::Buffer,
     channel::{mpsc as priority_mpsc, mpsc::Priority},
     context::{ServiceContext, SessionContext, SessionController},
     error::{DialerErrorKind, ListenErrorKind, ProtocolHandleErrorKind, TransportErrorKind},
@@ -51,7 +45,7 @@ pub(crate) mod future_task;
 mod helper;
 
 pub use crate::service::{
-    config::{BlockingFlag, ProtocolHandle, ProtocolMeta, TargetProtocol, TargetSession},
+    config::{ProtocolHandle, ProtocolMeta, TargetProtocol, TargetSession},
     control::{ServiceAsyncControl, ServiceControl},
     event::{ServiceError, ServiceEvent},
     helper::SessionType,
@@ -98,11 +92,11 @@ pub struct Service<T> {
     // Future task manager
     future_task_manager: Option<FutureTaskManager>,
     // To add a future task
-    future_task_sender: Buffer<BoxedFutureTask>,
+    future_task_sender: mpsc::Sender<BoxedFutureTask>,
 
-    service_proto_handles: IntMap<ProtocolId, Buffer<ServiceProtocolEvent>>,
+    service_proto_handles: IntMap<ProtocolId, mpsc::Sender<ServiceProtocolEvent>>,
 
-    session_proto_handles: HashMap<(SessionId, ProtocolId), Buffer<SessionProtocolEvent>>,
+    session_proto_handles: HashMap<(SessionId, ProtocolId), mpsc::Sender<SessionProtocolEvent>>,
 
     /// Send events to service, clone to session
     session_event_sender: mpsc::Sender<SessionEvent>,
@@ -165,7 +159,7 @@ where
                 let transport = transport.tls_config(config.tls_config.clone());
                 transport
             },
-            future_task_sender: Buffer::new(future_task_sender),
+            future_task_sender,
             future_task_manager: Some(FutureTaskManager::new(
                 future_task_receiver,
                 shutdown.clone(),
@@ -234,12 +228,14 @@ where
             Ok((addr, incoming)) => {
                 let listen_address = addr.clone();
 
-                self.handle.handle_event(
-                    &mut self.service_context,
-                    ServiceEvent::ListenStarted {
-                        address: listen_address.clone(),
-                    },
-                );
+                self.handle
+                    .handle_event(
+                        &mut self.service_context,
+                        ServiceEvent::ListenStarted {
+                            address: listen_address.clone(),
+                        },
+                    )
+                    .await;
                 #[cfg(feature = "upnp")]
                 if let Some(client) = self.igd_client.as_mut() {
                     client.register(&listen_address)
@@ -263,9 +259,9 @@ where
             max_frame_length: self.config.max_frame_length,
             timeout: self.config.timeout,
             listen_addr: listen_address,
-            future_task_sender: self.future_task_sender.clone_sender(),
+            future_task_sender: self.future_task_sender.clone(),
         };
-        let mut sender = self.future_task_sender.clone_sender();
+        let mut sender = self.future_task_sender.clone();
         crate::runtime::spawn(async move {
             let res = sender
                 .send(Box::pin(listener.for_each(|_| future::ready(()))))
@@ -296,7 +292,11 @@ where
                     error!("Listen address result send back error: {:?}", err);
                 }
             };
-            self.future_task_sender.push(Box::pin(task));
+            let mut sender = self.future_task_sender.clone();
+            crate::runtime::spawn(async move {
+                let _ignore = sender.send(Box::pin(task)).await;
+            });
+
             self.state.increase();
         }
 
@@ -357,128 +357,17 @@ where
             };
         };
 
-        self.future_task_sender.push(Box::pin(task));
+        let mut sender = self.future_task_sender.clone();
+        crate::runtime::spawn(async move {
+            let _ignore = sender.send(Box::pin(task)).await;
+        });
         self.state.increase();
         Ok(())
     }
 
     /// Get service control, control can send tasks externally to the runtime inside
-    pub fn control(&self) -> &ServiceControl {
+    pub fn control(&self) -> &ServiceAsyncControl {
         self.service_context.control()
-    }
-
-    /// Distribute event to sessions
-    #[inline]
-    fn distribute_to_session(&mut self, cx: &mut Context) {
-        if self.shutdown.load(Ordering::SeqCst) {
-            return;
-        }
-
-        for control in self
-            .sessions
-            .values_mut()
-            .filter(|control| !control.buffer.is_empty())
-        {
-            if let SendResult::Pending = control.try_send(cx) {
-                if control.inner.pending_data_size() > self.config.session_config.send_buffer_size {
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::SessionBlocked {
-                            session_context: control.inner.clone(),
-                        },
-                    );
-
-                    warn!(
-                        "session {:?} unable to send message, \
-                         user allow buffer size: {}, \
-                         current buffer size: {}, so kill it",
-                        control.inner,
-                        self.config.session_config.send_buffer_size,
-                        control.inner.pending_data_size()
-                    );
-
-                    // clean message and try to close this session
-                    control.buffer.clear();
-                    let id = control.inner.id;
-                    control.push(Priority::High, SessionEvent::SessionClose { id });
-                    control.try_send(cx);
-                }
-            }
-        }
-    }
-
-    /// Distribute event to user level
-    #[inline(always)]
-    fn distribute_to_user_level(&mut self, cx: &mut Context) {
-        if self.shutdown.load(Ordering::SeqCst) {
-            return;
-        }
-        let mut error = false;
-
-        for (proto_id, buffer) in self
-            .service_proto_handles
-            .iter_mut()
-            .filter(|(_, buffer)| !buffer.is_empty())
-        {
-            match buffer.try_send(cx) {
-                SendResult::Pending => {
-                    let error = ProtocolHandleErrorKind::Block(None);
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ProtocolHandleError {
-                            proto_id: *proto_id,
-                            error,
-                        },
-                    );
-                }
-                SendResult::Ok => (),
-                SendResult::Disconnect => {
-                    error = true;
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ProtocolHandleError {
-                            proto_id: *proto_id,
-                            error: ProtocolHandleErrorKind::AbnormallyClosed(None),
-                        },
-                    );
-                }
-            }
-        }
-
-        for ((session_id, proto_id), ref mut buffer) in self
-            .session_proto_handles
-            .iter_mut()
-            .filter(|(_, buffer)| !buffer.is_empty())
-        {
-            match buffer.try_send(cx) {
-                SendResult::Pending => {
-                    let error = ProtocolHandleErrorKind::Block(Some(*session_id));
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ProtocolHandleError {
-                            proto_id: *proto_id,
-                            error,
-                        },
-                    );
-                }
-                SendResult::Ok => (),
-                SendResult::Disconnect => {
-                    error = true;
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ProtocolHandleError {
-                            proto_id: *proto_id,
-                            error: ProtocolHandleErrorKind::AbnormallyClosed(Some(*session_id)),
-                        },
-                    )
-                }
-            }
-        }
-
-        if error {
-            // if handle panic, close service
-            self.handle_service_task(cx, ServiceTask::Shutdown(false), Priority::High);
-        }
     }
 
     /// Spawn protocol handle
@@ -496,24 +385,20 @@ where
                 if let Some(session_control) = self.sessions.get(&id) {
                     debug!("init session [{}] level proto [{}] handle", id, proto_id);
                     let (sender, receiver) = mpsc::channel(RECEIVED_SIZE);
-                    self.session_proto_handles
-                        .insert((id, *proto_id), Buffer::new(sender));
+                    self.session_proto_handles.insert((id, *proto_id), sender);
 
-                    let stream = SessionProtocolStream::new(
+                    let mut stream = SessionProtocolStream::new(
                         handle,
                         self.service_context.clone_self(),
                         Arc::clone(&session_control.inner),
                         receiver,
-                        (*proto_id, meta.blocking_flag()),
+                        *proto_id,
                         self.session_event_sender.clone(),
-                        (
-                            self.shutdown.clone(),
-                            self.future_task_sender.clone_sender(),
-                        ),
+                        (self.shutdown.clone(), self.future_task_sender.clone()),
                     );
                     let (sender, receiver) = futures::channel::oneshot::channel();
                     let handle = crate::runtime::spawn(async move {
-                        future::select(stream.for_each(|_| future::ready(())), receiver).await;
+                        future::select(Box::pin(stream.run()), receiver).await;
                     });
                     handles.push((Some(sender), handle));
                 }
@@ -524,9 +409,8 @@ where
         handles
     }
 
-    fn handle_message(
+    async fn handle_message(
         &mut self,
-        cx: &mut Context,
         target: TargetSession,
         proto_id: ProtocolId,
         priority: Priority,
@@ -541,25 +425,33 @@ where
             // Send data to the specified protocol for the specified session.
             TargetSession::Single(id) => {
                 if let Some(control) = self.sessions.get_mut(&id) {
-                    control.push_message(proto_id, priority, data);
-                    control.try_send(cx);
+                    control.inner.incr_pending_data_size(data.len());
+                    let _ignore = control
+                        .send(priority, SessionEvent::ProtocolMessage { proto_id, data })
+                        .await;
                 }
             }
             // Send data to the specified protocol for the specified sessions.
-            TargetSession::Filter(filter) => self
-                .sessions
-                .iter_mut()
-                .filter(|(id, _)| filter(id))
-                .for_each(|(id, control)| {
+            TargetSession::Filter(filter) => {
+                for (id, control) in self.sessions.iter_mut().filter(|(id, _)| filter(id)) {
                     debug!(
                         "send message to session [{}], proto [{}], data len: {}",
                         id,
                         proto_id,
                         data.len()
                     );
-                    control.push_message(proto_id, priority, data.clone());
-                    control.try_send(cx);
-                }),
+                    control.inner.incr_pending_data_size(data.len());
+                    let _ignore = control
+                        .send(
+                            priority,
+                            SessionEvent::ProtocolMessage {
+                                proto_id,
+                                data: data.clone(),
+                            },
+                        )
+                        .await;
+                }
+            }
             // Broadcast data for a specified protocol.
             TargetSession::All => {
                 debug!(
@@ -569,8 +461,16 @@ where
                     data.len()
                 );
                 for control in self.sessions.values_mut() {
-                    control.push_message(proto_id, priority, data.clone());
-                    control.try_send(cx);
+                    control.inner.incr_pending_data_size(data.len());
+                    let _ignore = control
+                        .send(
+                            priority,
+                            SessionEvent::ProtocolMessage {
+                                proto_id,
+                                data: data.clone(),
+                            },
+                        )
+                        .await;
                 }
             }
         }
@@ -598,7 +498,7 @@ where
         }
         .handshake(socket);
 
-        let mut future_task_sender = self.future_task_sender.clone_sender();
+        let mut future_task_sender = self.future_task_sender.clone();
 
         crate::runtime::spawn(async move {
             if future_task_sender
@@ -630,9 +530,8 @@ where
 
     /// Session open
     #[inline]
-    fn session_open<H>(
+    async fn session_open<H>(
         &mut self,
-        cx: &mut Context,
         mut handle: H,
         remote_pubkey: Option<PublicKey>,
         mut address: Multiaddr,
@@ -655,25 +554,29 @@ where
             {
                 Some(context) => {
                     trace!("Connected to the connected node");
-                    if let Poll::Ready(Err(e)) = Pin::new(&mut handle).poll_shutdown(cx) {
-                        trace!("handle poll shutdown err {}", e)
-                    }
+                    crate::runtime::spawn(async move {
+                        let _ignore = handle.shutdown().await;
+                    });
                     if ty.is_outbound() {
-                        self.handle.handle_error(
-                            &mut self.service_context,
-                            ServiceError::DialerError {
-                                error: DialerErrorKind::RepeatedConnection(context.inner.id),
-                                address,
-                            },
-                        );
+                        self.handle
+                            .handle_error(
+                                &mut self.service_context,
+                                ServiceError::DialerError {
+                                    error: DialerErrorKind::RepeatedConnection(context.inner.id),
+                                    address,
+                                },
+                            )
+                            .await;
                     } else {
-                        self.handle.handle_error(
-                            &mut self.service_context,
-                            ServiceError::ListenError {
-                                error: ListenErrorKind::RepeatedConnection(context.inner.id),
-                                address: listen_addr.expect("listen address must exist"),
-                            },
-                        );
+                        self.handle
+                            .handle_error(
+                                &mut self.service_context,
+                                ServiceError::ListenError {
+                                    error: ListenErrorKind::RepeatedConnection(context.inner.id),
+                                    address: listen_addr.expect("listen address must exist"),
+                                },
+                            )
+                            .await;
                     }
                     return;
                 }
@@ -682,13 +585,15 @@ where
                     if let Some(peer_id) = extract_peer_id(&address) {
                         if key.peer_id() != peer_id {
                             trace!("Peer id not match");
-                            self.handle.handle_error(
-                                &mut self.service_context,
-                                ServiceError::DialerError {
-                                    error: DialerErrorKind::PeerIdNotMatch,
-                                    address,
-                                },
-                            );
+                            self.handle
+                                .handle_error(
+                                    &mut self.service_context,
+                                    ServiceError::DialerError {
+                                        error: DialerErrorKind::PeerIdNotMatch,
+                                        address,
+                                    },
+                                )
+                                .await;
                             return;
                         }
                     } else {
@@ -742,13 +647,19 @@ where
         .protocol_by_id(by_id)
         .config(self.config.session_config)
         .keep_buffer(self.config.keep_buffer)
-        .service_proto_senders(self.service_proto_handles.clone())
+        .service_proto_senders(
+            self.service_proto_handles
+                .clone()
+                .into_iter()
+                .map(|(k, v)| (k, Buffer::new(v)))
+                .collect(),
+        )
         .session_senders(
             self.session_proto_handles
                 .iter()
                 .filter_map(|((session_id, key), value)| {
                     if *session_id == self.next_session {
-                        Some((*key, value.clone()))
+                        Some((*key, Buffer::new(value.clone())))
                     } else {
                         None
                     }
@@ -762,7 +673,7 @@ where
             self.session_event_sender.clone(),
             service_event_receiver,
             meta,
-            self.future_task_sender.clone_sender(),
+            self.future_task_sender.clone(),
         );
 
         if ty.is_outbound() {
@@ -787,20 +698,23 @@ where
 
         crate::runtime::spawn(session.for_each(|_| future::ready(())));
 
-        self.handle.handle_event(
-            &mut self.service_context,
-            ServiceEvent::SessionOpen { session_context },
-        );
+        self.handle
+            .handle_event(
+                &mut self.service_context,
+                ServiceEvent::SessionOpen { session_context },
+            )
+            .await;
     }
 
     /// Close the specified session, clean up the handle
     #[inline]
-    fn session_close(&mut self, cx: &mut Context, id: SessionId, source: Source) {
+    async fn session_close(&mut self, id: SessionId, source: Source) {
         if source == Source::External {
             if let Some(control) = self.sessions.get_mut(&id) {
-                control.push(Priority::High, SessionEvent::SessionClose { id });
                 debug!("try close service session [{}] ", id);
-                control.try_send(cx);
+                let _ignore = control
+                    .send(Priority::High, SessionEvent::SessionClose { id })
+                    .await;
             }
             return;
         }
@@ -812,43 +726,45 @@ where
 
         if let Some(session_control) = self.sessions.remove(&id) {
             // Service handle processing flow
-            self.handle.handle_event(
-                &mut self.service_context,
-                ServiceEvent::SessionClose {
-                    session_context: session_control.inner,
-                },
-            );
+            self.handle
+                .handle_event(
+                    &mut self.service_context,
+                    ServiceEvent::SessionClose {
+                        session_context: session_control.inner,
+                    },
+                )
+                .await;
         }
     }
 
     /// Open the handle corresponding to the protocol
     #[inline]
-    fn protocol_open(&mut self, cx: &mut Context, id: SessionId, proto_id: ProtocolId) {
+    async fn protocol_open(&mut self, id: SessionId, proto_id: ProtocolId) {
         if let Some(control) = self.sessions.get_mut(&id) {
-            control.push(Priority::High, SessionEvent::ProtocolOpen { proto_id });
             debug!("try open session [{}] proto [{}]", id, proto_id);
-            control.try_send(cx);
+            let _ignore = control
+                .send(Priority::High, SessionEvent::ProtocolOpen { proto_id })
+                .await;
         }
     }
 
     /// Protocol stream is closed, clean up data
     #[inline]
-    fn protocol_close(&mut self, cx: &mut Context, session_id: SessionId, proto_id: ProtocolId) {
+    async fn protocol_close(&mut self, session_id: SessionId, proto_id: ProtocolId) {
         if let Some(control) = self.sessions.get_mut(&session_id) {
-            control.push(Priority::High, SessionEvent::ProtocolClose { proto_id });
             debug!("try close session [{}] proto [{}]", session_id, proto_id);
-            control.try_send(cx);
+            let _ignore = control
+                .send(Priority::High, SessionEvent::ProtocolClose { proto_id })
+                .await;
         }
     }
 
-    fn send_pending_task(&mut self, cx: &mut Context) {
-        self.future_task_sender.try_send(cx);
-    }
-
     #[inline]
-    fn send_future_task(&mut self, cx: &mut Context, task: BoxedFutureTask) {
-        self.future_task_sender.push(task);
-        self.send_pending_task(cx)
+    fn send_future_task(&mut self, task: BoxedFutureTask) {
+        let mut sender = self.future_task_sender.clone();
+        crate::runtime::spawn(async move {
+            let _ignore = sender.send(task).await;
+        });
     }
 
     fn init_proto_handles(&mut self) {
@@ -856,24 +772,20 @@ where
             if let ProtocolHandle::Callback(handle) = meta.service_handle() {
                 debug!("init service level [{}] proto handle", proto_id);
                 let (sender, receiver) = mpsc::channel(RECEIVED_SIZE);
-                self.service_proto_handles
-                    .insert(*proto_id, Buffer::new(sender));
+                self.service_proto_handles.insert(*proto_id, sender);
 
                 let mut stream = ServiceProtocolStream::new(
                     handle,
                     self.service_context.clone_self(),
                     receiver,
-                    (*proto_id, meta.blocking_flag()),
+                    *proto_id,
                     self.session_event_sender.clone(),
-                    (
-                        self.shutdown.clone(),
-                        self.future_task_sender.clone_sender(),
-                    ),
+                    (self.shutdown.clone(), self.future_task_sender.clone()),
                 );
-                stream.handle_event(ServiceProtocolEvent::Init);
                 let (sender, receiver) = futures::channel::oneshot::channel();
                 let handle = crate::runtime::spawn(async move {
-                    future::select(stream.for_each(|_| future::ready(())), receiver).await;
+                    stream.handle_event(ServiceProtocolEvent::Init).await;
+                    future::select(Box::pin(stream.run()), receiver).await;
                 });
                 self.wait_handle.push((Some(sender), handle));
             } else {
@@ -888,7 +800,7 @@ where
     /// When listen update, call here
     #[cfg(not(target_arch = "wasm32"))]
     #[inline]
-    fn try_update_listens(&mut self, cx: &mut Context) {
+    async fn try_update_listens(&mut self) {
         #[cfg(feature = "upnp")]
         if let Some(client) = self.igd_client.as_mut() {
             client.process_only_leases_support()
@@ -899,25 +811,61 @@ where
         let new_listens = self.listens.iter().cloned().collect::<Vec<Multiaddr>>();
         self.service_context.update_listens(new_listens.clone());
 
-        for buffer in self.service_proto_handles.values_mut() {
-            buffer.push(ServiceProtocolEvent::Update {
-                listen_addrs: new_listens.clone(),
-            });
+        let mut error = false;
+
+        for (proto_id, sender) in self.service_proto_handles.iter_mut() {
+            if sender
+                .send(ServiceProtocolEvent::Update {
+                    listen_addrs: new_listens.clone(),
+                })
+                .await
+                .is_err()
+            {
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::ProtocolHandleError {
+                            proto_id: *proto_id,
+                            error: ProtocolHandleErrorKind::AbnormallyClosed(None),
+                        },
+                    )
+                    .await;
+                error = true;
+            }
         }
 
-        for buffer in self.session_proto_handles.values_mut() {
-            buffer.push(SessionProtocolEvent::Update {
-                listen_addrs: new_listens.clone(),
-            });
+        for ((session_id, proto_id), sender) in self.session_proto_handles.iter_mut() {
+            if sender
+                .send(SessionProtocolEvent::Update {
+                    listen_addrs: new_listens.clone(),
+                })
+                .await
+                .is_err()
+            {
+                error = true;
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::ProtocolHandleError {
+                            proto_id: *proto_id,
+                            error: ProtocolHandleErrorKind::AbnormallyClosed(Some(*session_id)),
+                        },
+                    )
+                    .await;
+            }
         }
 
-        self.distribute_to_user_level(cx);
+        if error {
+            // if handle panic, close service
+            self.handle_service_task(ServiceTask::Shutdown(false), Priority::High)
+                .await;
+        }
     }
 
     /// Handling various events uploaded by the session
-    fn handle_session_event(&mut self, cx: &mut Context, event: SessionEvent) {
+    async fn handle_session_event(&mut self, event: SessionEvent) {
         match event {
-            SessionEvent::SessionClose { id } => self.session_close(cx, id, Source::Internal),
+            SessionEvent::SessionClose { id } => self.session_close(id, Source::Internal).await,
             SessionEvent::HandshakeSuccess {
                 handle,
                 public_key,
@@ -929,20 +877,23 @@ where
                     self.state.decrease();
                 }
                 if !self.reached_max_connection_limit() {
-                    self.session_open(cx, handle, public_key, address, ty, listen_address);
+                    self.session_open(handle, public_key, address, ty, listen_address)
+                        .await;
                 }
             }
             SessionEvent::HandshakeError { ty, error, address } => {
                 if ty.is_outbound() {
                     self.state.decrease();
                     self.dial_protocols.remove(&address);
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::DialerError {
-                            address,
-                            error: DialerErrorKind::HandshakeError(error),
-                        },
-                    )
+                    self.handle
+                        .handle_error(
+                            &mut self.service_context,
+                            ServiceError::DialerError {
+                                address,
+                                error: DialerErrorKind::HandshakeError(error),
+                            },
+                        )
+                        .await
                 }
             }
             SessionEvent::ProtocolMessage { .. }
@@ -950,57 +901,69 @@ where
             | SessionEvent::ProtocolClose { .. } => unreachable!(),
             SessionEvent::ProtocolSelectError { id, proto_name } => {
                 if let Some(session_control) = self.sessions.get(&id) {
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::ProtocolSelectError {
-                            proto_name,
-                            session_context: Arc::clone(&session_control.inner),
-                        },
-                    )
+                    self.handle
+                        .handle_error(
+                            &mut self.service_context,
+                            ServiceError::ProtocolSelectError {
+                                proto_name,
+                                session_context: Arc::clone(&session_control.inner),
+                            },
+                        )
+                        .await
                 }
             }
             SessionEvent::ProtocolError {
                 id,
                 proto_id,
                 error,
-            } => self.handle.handle_error(
-                &mut self.service_context,
-                ServiceError::ProtocolError {
-                    id,
-                    proto_id,
-                    error,
-                },
-            ),
+            } => {
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::ProtocolError {
+                            id,
+                            proto_id,
+                            error,
+                        },
+                    )
+                    .await
+            }
             SessionEvent::DialError { address, error } => {
                 self.state.decrease();
                 self.dial_protocols.remove(&address);
-                self.handle.handle_error(
-                    &mut self.service_context,
-                    ServiceError::DialerError {
-                        address,
-                        error: DialerErrorKind::TransportError(error),
-                    },
-                )
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::DialerError {
+                            address,
+                            error: DialerErrorKind::TransportError(error),
+                        },
+                    )
+                    .await
             }
             #[cfg(not(target_arch = "wasm32"))]
             SessionEvent::ListenError { address, error } => {
-                self.handle.handle_error(
-                    &mut self.service_context,
-                    ServiceError::ListenError {
-                        address: address.clone(),
-                        error: ListenErrorKind::TransportError(error),
-                    },
-                );
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::ListenError {
+                            address: address.clone(),
+                            error: ListenErrorKind::TransportError(error),
+                        },
+                    )
+                    .await;
                 if self.listens.remove(&address) {
                     #[cfg(feature = "upnp")]
                     if let Some(ref mut client) = self.igd_client {
                         client.remove(&address);
                     }
 
-                    self.handle.handle_event(
-                        &mut self.service_context,
-                        ServiceEvent::ListenClose { address },
-                    )
+                    self.handle
+                        .handle_event(
+                            &mut self.service_context,
+                            ServiceEvent::ListenClose { address },
+                        )
+                        .await
                 } else {
                     // try start listen error
                     self.state.decrease();
@@ -1008,23 +971,27 @@ where
             }
             SessionEvent::SessionTimeout { id } => {
                 if let Some(session_control) = self.sessions.get(&id) {
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::SessionTimeout {
-                            session_context: Arc::clone(&session_control.inner),
-                        },
-                    )
+                    self.handle
+                        .handle_error(
+                            &mut self.service_context,
+                            ServiceError::SessionTimeout {
+                                session_context: Arc::clone(&session_control.inner),
+                            },
+                        )
+                        .await
                 }
             }
             SessionEvent::MuxerError { id, error } => {
                 if let Some(session_control) = self.sessions.get(&id) {
-                    self.handle.handle_error(
-                        &mut self.service_context,
-                        ServiceError::MuxerError {
-                            session_context: Arc::clone(&session_control.inner),
-                            error,
-                        },
-                    )
+                    self.handle
+                        .handle_error(
+                            &mut self.service_context,
+                            ServiceError::MuxerError {
+                                session_context: Arc::clone(&session_control.inner),
+                                error,
+                            },
+                        )
+                        .await
                 }
             }
             #[cfg(not(target_arch = "wasm32"))]
@@ -1032,15 +999,17 @@ where
                 listen_address,
                 incoming,
             } => {
-                self.handle.handle_event(
-                    &mut self.service_context,
-                    ServiceEvent::ListenStarted {
-                        address: listen_address.clone(),
-                    },
-                );
+                self.handle
+                    .handle_event(
+                        &mut self.service_context,
+                        ServiceEvent::ListenStarted {
+                            address: listen_address.clone(),
+                        },
+                    )
+                    .await;
                 self.listens.insert(listen_address.clone());
                 self.state.decrease();
-                self.try_update_listens(cx);
+                self.try_update_listens().await;
                 #[cfg(feature = "upnp")]
                 if let Some(client) = self.igd_client.as_mut() {
                     client.register(&listen_address)
@@ -1048,12 +1017,15 @@ where
                 self.spawn_listener(incoming, listen_address);
             }
             SessionEvent::ProtocolHandleError { error, proto_id } => {
-                self.handle.handle_error(
-                    &mut self.service_context,
-                    ServiceError::ProtocolHandleError { error, proto_id },
-                );
+                self.handle
+                    .handle_error(
+                        &mut self.service_context,
+                        ServiceError::ProtocolHandleError { error, proto_id },
+                    )
+                    .await;
                 // if handle panic, close service
-                self.handle_service_task(cx, ServiceTask::Shutdown(false), Priority::High);
+                self.handle_service_task(ServiceTask::Shutdown(false), Priority::High)
+                    .await;
             }
             _ => (),
         }
@@ -1061,46 +1033,50 @@ where
 
     /// Handling various tasks sent externally
     #[allow(clippy::needless_collect)]
-    fn handle_service_task(&mut self, cx: &mut Context, event: ServiceTask, priority: Priority) {
+    async fn handle_service_task(&mut self, event: ServiceTask, priority: Priority) {
         match event {
             ServiceTask::ProtocolMessage {
                 target,
                 proto_id,
                 data,
             } => {
-                self.handle_message(cx, target, proto_id, priority, data);
+                self.handle_message(target, proto_id, priority, data).await;
             }
             ServiceTask::Dial { address, target } => {
                 if !self.dial_protocols.contains_key(&address) {
                     if let Err(e) = self.dial_inner(address.clone(), target) {
-                        self.handle.handle_error(
-                            &mut self.service_context,
-                            ServiceError::DialerError {
-                                address,
-                                error: DialerErrorKind::TransportError(e),
-                            },
-                        );
+                        self.handle
+                            .handle_error(
+                                &mut self.service_context,
+                                ServiceError::DialerError {
+                                    address,
+                                    error: DialerErrorKind::TransportError(e),
+                                },
+                            )
+                            .await;
                     }
                 }
             }
             ServiceTask::Listen { address } => {
                 if !self.listens.contains(&address) {
                     if let Err(e) = self.listen_inner(address.clone()) {
-                        self.handle.handle_error(
-                            &mut self.service_context,
-                            ServiceError::ListenError {
-                                address,
-                                error: ListenErrorKind::TransportError(e),
-                            },
-                        );
+                        self.handle
+                            .handle_error(
+                                &mut self.service_context,
+                                ServiceError::ListenError {
+                                    address,
+                                    error: ListenErrorKind::TransportError(e),
+                                },
+                            )
+                            .await;
                     }
                 }
             }
             ServiceTask::Disconnect { session_id } => {
-                self.session_close(cx, session_id, Source::External)
+                self.session_close(session_id, Source::External).await
             }
             ServiceTask::FutureTask { task } => {
-                self.send_future_task(cx, task);
+                self.send_future_task(task);
             }
             ServiceTask::SetProtocolNotify {
                 proto_id,
@@ -1108,15 +1084,17 @@ where
                 token,
             } => {
                 // TODO: if not contains should call handle_error let user know
-                if let Some(buffer) = self.service_proto_handles.get_mut(&proto_id) {
-                    buffer.push(ServiceProtocolEvent::SetNotify { interval, token });
-                    buffer.try_send(cx);
+                if let Some(sender) = self.service_proto_handles.get_mut(&proto_id) {
+                    let _ignore = sender
+                        .send(ServiceProtocolEvent::SetNotify { interval, token })
+                        .await;
                 }
             }
             ServiceTask::RemoveProtocolNotify { proto_id, token } => {
-                if let Some(buffer) = self.service_proto_handles.get_mut(&proto_id) {
-                    buffer.push(ServiceProtocolEvent::RemoveNotify { token });
-                    buffer.try_send(cx);
+                if let Some(sender) = self.service_proto_handles.get_mut(&proto_id) {
+                    let _ignore = sender
+                        .send(ServiceProtocolEvent::RemoveNotify { token })
+                        .await;
                 }
             }
             ServiceTask::SetProtocolSessionNotify {
@@ -1126,9 +1104,10 @@ where
                 token,
             } => {
                 // TODO: if not contains should call handle_error let user know
-                if let Some(buffer) = self.session_proto_handles.get_mut(&(session_id, proto_id)) {
-                    buffer.push(SessionProtocolEvent::SetNotify { interval, token });
-                    buffer.try_send(cx);
+                if let Some(sender) = self.session_proto_handles.get_mut(&(session_id, proto_id)) {
+                    let _ignore = sender
+                        .send(SessionProtocolEvent::SetNotify { interval, token })
+                        .await;
                 }
             }
             ServiceTask::RemoveProtocolSessionNotify {
@@ -1136,9 +1115,10 @@ where
                 proto_id,
                 token,
             } => {
-                if let Some(buffer) = self.session_proto_handles.get_mut(&(session_id, proto_id)) {
-                    buffer.push(SessionProtocolEvent::RemoveNotify { token });
-                    buffer.try_send(cx);
+                if let Some(sender) = self.session_proto_handles.get_mut(&(session_id, proto_id)) {
+                    let _ignore = sender
+                        .send(SessionProtocolEvent::RemoveNotify { token })
+                        .await;
                 }
             }
             ServiceTask::ProtocolOpen { session_id, target } => match target {
@@ -1147,37 +1127,39 @@ where
                     #[allow(clippy::needless_collect)]
                     {
                         let ids = self.protocol_configs.keys().copied().collect::<Vec<_>>();
-                        ids.into_iter()
-                            .for_each(|id| self.protocol_open(cx, session_id, id));
+                        for id in ids {
+                            self.protocol_open(session_id, id).await
+                        }
                     }
                 }
-                TargetProtocol::Single(id) => self.protocol_open(cx, session_id, id),
+                TargetProtocol::Single(id) => self.protocol_open(session_id, id).await,
                 TargetProtocol::Filter(filter) => {
                     let ids = self.protocol_configs.keys().copied().collect::<Vec<_>>();
-                    ids.into_iter()
-                        .filter(filter)
-                        .for_each(|id| self.protocol_open(cx, session_id, id))
+                    for id in ids.into_iter().filter(filter) {
+                        self.protocol_open(session_id, id).await
+                    }
                 }
             },
             ServiceTask::ProtocolClose {
                 session_id,
                 proto_id,
-            } => self.protocol_close(cx, session_id, proto_id),
+            } => self.protocol_close(session_id, proto_id).await,
             ServiceTask::Shutdown(quick) => {
                 self.state.pre_shutdown();
 
                 for address in self.listens.drain() {
-                    self.handle.handle_event(
-                        &mut self.service_context,
-                        ServiceEvent::ListenClose { address },
-                    )
+                    self.handle
+                        .handle_event(
+                            &mut self.service_context,
+                            ServiceEvent::ListenClose { address },
+                        )
+                        .await
                 }
                 // clear upnp register
                 #[cfg(all(not(target_arch = "wasm32"), feature = "upnp"))]
                 if let Some(client) = self.igd_client.as_mut() {
                     client.clear()
                 };
-                self.future_task_sender.clear();
 
                 let sessions = self.sessions.keys().cloned().collect::<Vec<SessionId>>();
 
@@ -1189,101 +1171,31 @@ where
                     self.session_proto_handles.clear();
 
                     // don't care about any session action
-                    sessions
-                        .into_iter()
-                        .for_each(|i| self.session_close(cx, i, Source::Internal));
+                    for i in sessions {
+                        self.session_close(i, Source::Internal).await
+                    }
                 } else {
-                    sessions
-                        .into_iter()
-                        .for_each(|i| self.session_close(cx, i, Source::External));
+                    for i in sessions {
+                        self.session_close(i, Source::External).await
+                    }
                 }
             }
         }
     }
 
-    #[inline]
-    fn user_task_poll(&mut self, cx: &mut Context) -> Poll<Option<()>> {
-        if self.service_task_receiver.is_terminated() {
-            return Poll::Ready(None);
-        }
-
-        match Pin::new(&mut self.service_task_receiver)
-            .as_mut()
-            .poll_next(cx)
-        {
-            Poll::Ready(Some((priority, task))) => {
-                self.handle_service_task(cx, task, priority);
-                Poll::Ready(Some(()))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-
-    fn session_poll(&mut self, cx: &mut Context) -> Poll<Option<()>> {
-        if self.session_event_receiver.is_terminated() {
-            return Poll::Ready(None);
-        }
-
-        match Pin::new(&mut self.session_event_receiver)
-            .as_mut()
-            .poll_next(cx)
-        {
-            Poll::Ready(Some(event)) => {
-                self.handle_session_event(cx, event);
-                Poll::Ready(Some(()))
-            }
-            Poll::Ready(None) => unreachable!(),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-
-    fn flush_buffer(&mut self, cx: &mut Context) {
-        self.distribute_to_session(cx);
-
-        self.distribute_to_user_level(cx);
-    }
-
     #[cold]
-    fn wait_handle_poll(&mut self, cx: &mut Context) -> Poll<Option<()>> {
-        for (sender, mut handle) in self.wait_handle.split_off(0) {
+    async fn wait_handle_poll(&mut self) {
+        for (sender, handle) in self.wait_handle.split_off(0) {
             if let Some(sender) = sender {
                 // don't care about it
                 let _ignore = sender.send(());
             }
-            match handle.poll_unpin(cx) {
-                Poll::Pending => {
-                    self.wait_handle.push((None, handle));
-                }
-                Poll::Ready(_) => (),
-            }
-        }
-
-        if self.wait_handle.is_empty() {
-            Poll::Ready(None)
-        } else {
-            Poll::Pending
+            let _ignore = handle.await;
         }
     }
-}
 
-impl<T> Stream for Service<T>
-where
-    T: ServiceHandle + Unpin,
-{
-    type Item = ();
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if self.listens.is_empty()
-            && self.state.is_shutdown()
-            && self.sessions.is_empty()
-            && self.future_task_sender.is_empty()
-        {
-            debug!("shutdown because all state is empty head");
-            self.shutdown.store(true, Ordering::SeqCst);
-            return self.wait_handle_poll(cx);
-        }
-
+    /// start service
+    pub async fn run(&mut self) -> Option<()> {
         if let Some(stream) = self.future_task_manager.take() {
             let (sender, receiver) = futures::channel::oneshot::channel();
             let handle = crate::runtime::spawn(async move {
@@ -1293,57 +1205,26 @@ where
             self.init_proto_handles();
         }
 
-        self.flush_buffer(cx);
-
-        #[cfg(not(target_arch = "wasm32"))]
-        self.try_update_listens(cx);
-
-        let mut is_pending = self.session_poll(cx).is_pending();
-
-        // receive user task
-        is_pending &= self.user_task_poll(cx).is_pending();
-
-        // process any task buffer
-        self.send_pending_task(cx);
-
-        // Double check service state
-        if self.listens.is_empty()
-            && self.state.is_shutdown()
-            && self.sessions.is_empty()
-            && self.future_task_sender.is_empty()
-        {
-            debug!("shutdown because all state is empty tail");
+        if self.listens.is_empty() && self.state.is_shutdown() && self.sessions.is_empty() {
+            debug!("shutdown because all state is empty head");
             self.shutdown.store(true, Ordering::SeqCst);
-            return self.wait_handle_poll(cx);
+            self.wait_handle_poll().await;
+            return None;
         }
-
-        if log_enabled!(target: "tentacle", log::Level::Debug) {
-            debug!(
-                "listens count: {}, state: {:?}, sessions count: {}, \
-             pending task: {}, write_buf: {}, read_service_buf: {}, read_session_buf: {}",
-                self.listens.len(),
-                self.state,
-                self.sessions.len(),
-                self.future_task_sender.len(),
-                self.sessions
-                    .values()
-                    .map(|item| item.buffer.len())
-                    .sum::<usize>(),
-                self.service_proto_handles
-                    .values()
-                    .map(Buffer::len)
-                    .sum::<usize>(),
-                self.session_proto_handles
-                    .values()
-                    .map(Buffer::len)
-                    .sum::<usize>(),
-            );
+        #[cfg(not(target_arch = "wasm32"))]
+        self.try_update_listens().await;
+        tokio::select! {
+            event = self.session_event_receiver.next() => {
+                if let Some(event) = event {
+                    self.handle_session_event(event).await
+                }
+            },
+            event = self.service_task_receiver.next() => {
+                if let Some((priority, task)) = event {
+                    self.handle_service_task(task, priority).await
+                }
+            }
         }
-
-        if is_pending {
-            Poll::Pending
-        } else {
-            Poll::Ready(Some(()))
-        }
+        Some(())
     }
 }

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -398,7 +398,7 @@ where
                     );
                     let (sender, receiver) = futures::channel::oneshot::channel();
                     let handle = crate::runtime::spawn(async move {
-                        future::select(Box::pin(stream.run()), receiver).await;
+                        stream.run(receiver).await;
                     });
                     handles.push((Some(sender), handle));
                 }
@@ -785,7 +785,7 @@ where
                 let (sender, receiver) = futures::channel::oneshot::channel();
                 let handle = crate::runtime::spawn(async move {
                     stream.handle_event(ServiceProtocolEvent::Init).await;
-                    future::select(Box::pin(stream.run()), receiver).await;
+                    stream.run(receiver).await;
                 });
                 self.wait_handle.push((Some(sender), handle));
             } else {

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -83,6 +83,7 @@ impl Default for SessionConfig {
 /// tls config wrap for server setup
 #[derive(Clone, Default)]
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub struct TlsConfig {
     /// tls server end config
     pub(crate) tls_server_config: Option<Arc<ServerConfig>>,
@@ -93,6 +94,7 @@ pub struct TlsConfig {
 }
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 impl TlsConfig {
     /// new TlsConfig
     pub fn new(server_config: Option<ServerConfig>, client_config: Option<ClientConfig>) -> Self {

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -162,7 +162,6 @@ pub struct ProtocolMeta {
     pub(crate) service_handle: ProtocolHandle<Box<dyn ServiceProtocol + Send + 'static + Unpin>>,
     pub(crate) session_handle: SessionHandleFn,
     pub(crate) before_send: Option<Box<dyn Fn(bytes::Bytes) -> bytes::Bytes + Send + 'static>>,
-    pub(crate) flag: BlockingFlag,
 }
 
 impl ProtocolMeta {
@@ -225,11 +224,6 @@ impl ProtocolMeta {
     ) -> ProtocolHandle<Box<dyn SessionProtocol + Send + 'static + Unpin>> {
         (self.session_handle)()
     }
-
-    /// Control whether the protocol handle method requires blocking to run
-    pub fn blocking_flag(&self) -> BlockingFlag {
-        self.flag
-    }
 }
 
 pub(crate) struct Meta {
@@ -265,89 +259,6 @@ impl<T> ProtocolHandle<T> {
     #[inline]
     pub fn is_none(&self) -> bool {
         matches!(self, ProtocolHandle::None)
-    }
-}
-
-/// Control whether the protocol handle method requires blocking to run
-/// default is 0b1111, all function use blocking
-///
-/// flag & 0b1000 > 0 means `connected` use blocking
-/// flag & 0b0100 > 0 means `disconnected` use blocking
-/// flag & 0b0010 > 0 means `received` use blocking
-/// flag & 0b0001 > 0 means `notify` use blocking
-#[derive(Copy, Clone, Debug)]
-pub struct BlockingFlag(u8);
-
-impl BlockingFlag {
-    /// connected don't use blocking
-    #[inline]
-    pub fn disable_connected(&mut self) {
-        self.0 &= 0b0111
-    }
-
-    /// disconnected don't use blocking
-    #[inline]
-    pub fn disable_disconnected(&mut self) {
-        self.0 &= 0b1011
-    }
-
-    /// received don't use blocking
-    #[inline]
-    pub fn disable_received(&mut self) {
-        self.0 &= 0b1101
-    }
-
-    /// notify don't use blocking
-    pub fn disable_notify(&mut self) {
-        self.0 &= 0b1110
-    }
-
-    /// all function use blocking
-    #[inline]
-    pub fn enable_all(&mut self) {
-        self.0 |= 0b1111
-    }
-
-    /// all function don't use blocking
-    #[inline]
-    pub fn disable_all(&mut self) {
-        self.0 &= 0b0000
-    }
-
-    /// return true if connected enable
-    #[inline]
-    pub const fn connected(self) -> bool {
-        self.0 & 0b1000 > 0
-    }
-
-    /// return true if disconnected enable
-    #[inline]
-    pub const fn disconnected(self) -> bool {
-        self.0 & 0b0100 > 0
-    }
-
-    /// return true if received enable
-    #[inline]
-    pub const fn received(self) -> bool {
-        self.0 & 0b0010 > 0
-    }
-
-    /// return true if notify enable
-    #[inline]
-    pub const fn notify(self) -> bool {
-        self.0 & 0b0001 > 0
-    }
-}
-
-impl Default for BlockingFlag {
-    fn default() -> Self {
-        BlockingFlag(0b1111)
-    }
-}
-
-impl From<u8> for BlockingFlag {
-    fn from(inner: u8) -> BlockingFlag {
-        BlockingFlag(inner)
     }
 }
 
@@ -415,7 +326,7 @@ impl State {
 
 #[cfg(test)]
 mod test {
-    use super::{BlockingFlag, State};
+    use super::State;
 
     #[test]
     fn test_state_no_forever() {
@@ -449,31 +360,5 @@ mod test {
         state.increase();
         state.pre_shutdown();
         assert_eq!(state, State::PreShutdown);
-    }
-
-    #[test]
-    fn test_proto_flag() {
-        let mut p = BlockingFlag::default();
-
-        assert_eq!(p.connected(), true);
-        assert_eq!(p.disconnected(), true);
-        assert_eq!(p.received(), true);
-        assert_eq!(p.notify(), true);
-
-        p.disable_connected();
-        assert_eq!(p.connected(), false);
-        p.disable_disconnected();
-        assert_eq!(p.disconnected(), false);
-        p.disable_received();
-        assert_eq!(p.received(), false);
-        p.disable_notify();
-        assert_eq!(p.notify(), false);
-
-        p.enable_all();
-        p.disable_all();
-        assert_eq!(p.connected(), false);
-        assert_eq!(p.disconnected(), false);
-        assert_eq!(p.received(), false);
-        assert_eq!(p.notify(), false);
     }
 }

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -25,7 +25,7 @@ use crate::{
     service::{
         config::{Meta, SessionConfig},
         future_task::BoxedFutureTask,
-        ServiceControl, SessionType, RECEIVED_SIZE, SEND_SIZE,
+        ServiceAsyncControl, SessionType, RECEIVED_SIZE, SEND_SIZE,
     },
     substream::{ProtocolEvent, SubstreamBuilder, SubstreamWritePartBuilder},
     transports::MultiIncoming,
@@ -152,7 +152,7 @@ pub(crate) struct Session {
     state: SessionState,
 
     context: Arc<SessionContext>,
-    service_control: ServiceControl,
+    service_control: ServiceAsyncControl,
 
     next_stream: StreamId,
 
@@ -808,7 +808,7 @@ pub(crate) struct SessionMeta {
     service_proto_senders: IntMap<ProtocolId, Buffer<ServiceProtocolEvent>>,
     session_proto_senders: IntMap<ProtocolId, Buffer<SessionProtocolEvent>>,
     event_sender: priority_mpsc::Sender<SessionEvent>,
-    service_control: ServiceControl,
+    service_control: ServiceAsyncControl,
     session_proto_handles: Vec<(
         Option<futures::channel::oneshot::Sender<()>>,
         crate::runtime::JoinHandle<()>,
@@ -820,7 +820,7 @@ impl SessionMeta {
         timeout: Duration,
         context: Arc<SessionContext>,
         event_sender: priority_mpsc::Sender<SessionEvent>,
-        control: ServiceControl,
+        control: ServiceAsyncControl,
     ) -> Self {
         SessionMeta {
             config: SessionConfig::default(),

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -101,6 +101,7 @@ pub(crate) enum SessionEvent {
         stream: StreamHandle,
     },
     ChangeState {
+        id: SessionId,
         state: SessionState,
         error: Option<io::Error>,
     },
@@ -210,8 +211,9 @@ impl Session {
             }
         });
         // background inner socket
+        let sid = meta.context.id;
         crate::runtime::spawn(
-            InnerSocket::new(socket, meta.event_sender).for_each(|_| future::ready(())),
+            InnerSocket::new(socket, meta.event_sender, sid).for_each(|_| future::ready(())),
         );
 
         Session {
@@ -356,6 +358,14 @@ impl Session {
                         self.context.pending_data_size()
                     );
                     buffer.clear();
+                    self.event_output(
+                        cx,
+                        SessionEvent::ChangeState {
+                            id: self.context.id,
+                            state: SessionState::Abnormal,
+                            error: None,
+                        },
+                    );
                 }
                 break;
             }
@@ -590,20 +600,14 @@ impl Session {
                 }
             }
             SessionEvent::StreamStart { stream } => self.handle_substream(stream),
-            SessionEvent::ChangeState { state, error } => {
+            SessionEvent::ChangeState { state, error, id } => {
                 if self.state == SessionState::Normal {
                     self.state = state;
                     if let Some(err) = error {
                         if !self.keep_buffer {
                             self.service_sender.clear()
                         }
-                        self.event_output(
-                            cx,
-                            SessionEvent::MuxerError {
-                                id: self.context.id,
-                                error: err,
-                            },
-                        )
+                        self.event_output(cx, SessionEvent::MuxerError { id, error: err })
                     }
                 }
             }
@@ -913,14 +917,19 @@ impl SessionState {
 struct InnerSocket<T> {
     socket: YamuxSession<T>,
     sender: priority_mpsc::Sender<SessionEvent>,
+    id: SessionId,
 }
 
 impl<T> InnerSocket<T>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send,
 {
-    fn new(socket: YamuxSession<T>, sender: priority_mpsc::Sender<SessionEvent>) -> Self {
-        InnerSocket { socket, sender }
+    fn new(
+        socket: YamuxSession<T>,
+        sender: priority_mpsc::Sender<SessionEvent>,
+        id: SessionId,
+    ) -> Self {
+        InnerSocket { socket, sender, id }
     }
 }
 
@@ -945,12 +954,14 @@ where
             }
             Poll::Ready(None) => {
                 let mut sender = self.sender.clone();
+                let id = self.id;
 
                 crate::runtime::spawn(async move {
                     let _ignore = sender
                         .quick_send(SessionEvent::ChangeState {
                             state: SessionState::RemoteClose,
                             error: None,
+                            id,
                         })
                         .await;
                 });
@@ -968,6 +979,7 @@ where
                     | ErrorKind::UnexpectedEof => SessionEvent::ChangeState {
                         state: SessionState::RemoteClose,
                         error: None,
+                        id: self.id,
                     },
                     _ => {
                         debug!("MuxerError: {:?}", err);
@@ -975,6 +987,7 @@ where
                         SessionEvent::ChangeState {
                             state: SessionState::Abnormal,
                             error: Some(err),
+                            id: self.id,
                         }
                     }
                 };

--- a/tentacle/src/traits.rs
+++ b/tentacle/src/traits.rs
@@ -243,6 +243,7 @@ impl SessionProtocol for Box<dyn SessionProtocol + Send + Sync + 'static + Unpin
 /// This trait implementation and the callback implementation are mutually exclusive, and will be
 /// checked during construction, if both exist, it will panic
 #[cfg_attr(not(feature = "unstable"), doc(hidden))]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub trait ProtocolSpawn {
     /// Call on protocol opened
     fn spawn(

--- a/tentacle/src/traits.rs
+++ b/tentacle/src/traits.rs
@@ -8,224 +8,228 @@ use crate::{
     substream::SubstreamReadPart,
 };
 
-pub use inner::*;
+/// Service handle
+///
+/// #### Note
+///
+/// All functions on this trait will block the entire server running, do not insert long-time tasks,
+/// you can use the futures task instead.
+///
+/// #### Behavior
+///
+/// The handle that exists when the Service is created.
+///
+/// Mainly handle some Service-level errors thrown at runtime, such as listening errors.
+///
+/// At the same time, the session establishment and disconnection messages will also be perceived here.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait ServiceHandle: Send {
+    /// Handling runtime errors
+    async fn handle_error(&mut self, _control: &mut ServiceContext, _error: ServiceError) {}
+    /// Handling session establishment and disconnection events
+    async fn handle_event(&mut self, _control: &mut ServiceContext, _event: ServiceEvent) {}
+}
 
-#[cfg(not(target_arch = "wasm32"))]
-mod inner {
-    use super::*;
-    /// Service handle
+/// Service level protocol handle
+///
+/// #### Note
+///
+/// All functions on this trait will block the entire server running, do not insert long-time tasks,
+/// you can use the futures task instead.
+///
+/// #### Behavior
+///
+/// Define the behavior of each custom protocol in each state.
+///
+/// Depending on whether the user defines a service handle or a session exclusive handle,
+/// the runtime has different performance.
+///
+/// The **important difference** is that some state values are allowed in the service handle,
+/// and the handle exclusive to the session is "stateless", relative to the service handle,
+/// it can only retain the information between a protocol stream on and off.
+///
+/// The opening and closing of the protocol will create and clean up the handle exclusive
+/// to the session, but the service handle will remain in the state until the service is closed.
+///
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait ServiceProtocol: Send {
+    /// This function is called when the service start.
     ///
-    /// #### Note
-    ///
-    /// All functions on this trait will block the entire server running, do not insert long-time tasks,
-    /// you can use the futures task instead.
-    ///
-    /// #### Behavior
-    ///
-    /// The handle that exists when the Service is created.
-    ///
-    /// Mainly handle some Service-level errors thrown at runtime, such as listening errors.
-    ///
-    /// At the same time, the session establishment and disconnection messages will also be perceived here.
-    #[async_trait::async_trait]
-    pub trait ServiceHandle: Send {
-        /// Handling runtime errors
-        async fn handle_error(&mut self, _control: &mut ServiceContext, _error: ServiceError) {}
-        /// Handling session establishment and disconnection events
-        async fn handle_event(&mut self, _control: &mut ServiceContext, _event: ServiceEvent) {}
+    /// The service handle will only be called once
+    async fn init(&mut self, context: &mut ProtocolContext);
+    /// Called when opening protocol
+    async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
+    /// Called when closing protocol
+    async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
+    /// Called when the corresponding protocol message is received
+    async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
+    /// Called when the Service receives the notify task
+    async fn notify(&mut self, _context: &mut ProtocolContext, _token: u64) {}
+    /// Behave like `Stream::poll_next`, but nothing output
+    /// if ready with Some, it will continue poll immediately
+    /// if ready with None, it will don't try to call the function again
+    #[inline]
+    async fn poll(&mut self, _context: &mut ProtocolContext) -> Option<()> {
+        None
+    }
+}
+
+/// Session level protocol handle
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait SessionProtocol: Send {
+    /// Called when opening protocol
+    async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
+    /// Called when closing protocol
+    async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
+    /// Called when the corresponding protocol message is received
+    async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
+    /// Called when the session receives the notify task
+    async fn notify(&mut self, _context: ProtocolContextMutRef<'_>, _token: u64) {}
+    /// Behave like `Stream::poll_next`, but nothing output
+    /// if ready with Some, it will continue poll immediately
+    /// if ready with None, it will don't try to call the function again
+    #[inline]
+    async fn poll(&mut self, _context: ProtocolContextMutRef<'_>) -> Option<()> {
+        None
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ServiceHandle for Box<dyn ServiceHandle + Send + 'static> {
+    async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
+        (&mut **self).handle_error(control, error).await
     }
 
-    /// Service level protocol handle
-    ///
-    /// #### Note
-    ///
-    /// All functions on this trait will block the entire server running, do not insert long-time tasks,
-    /// you can use the futures task instead.
-    ///
-    /// #### Behavior
-    ///
-    /// Define the behavior of each custom protocol in each state.
-    ///
-    /// Depending on whether the user defines a service handle or a session exclusive handle,
-    /// the runtime has different performance.
-    ///
-    /// The **important difference** is that some state values are allowed in the service handle,
-    /// and the handle exclusive to the session is "stateless", relative to the service handle,
-    /// it can only retain the information between a protocol stream on and off.
-    ///
-    /// The opening and closing of the protocol will create and clean up the handle exclusive
-    /// to the session, but the service handle will remain in the state until the service is closed.
-    ///
-    #[async_trait::async_trait]
-    pub trait ServiceProtocol: Send {
-        /// This function is called when the service start.
-        ///
-        /// The service handle will only be called once
-        async fn init(&mut self, context: &mut ProtocolContext);
-        /// Called when opening protocol
-        async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
-        /// Called when closing protocol
-        async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
-        /// Called when the corresponding protocol message is received
-        async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
-        /// Called when the Service receives the notify task
-        async fn notify(&mut self, _context: &mut ProtocolContext, _token: u64) {}
-        /// Behave like `Stream::poll_next`, but nothing output
-        /// if ready with Some, it will continue poll immediately
-        /// if ready with None, it will don't try to call the function again
-        #[inline]
-        async fn poll(&mut self, _context: &mut ProtocolContext) -> Option<()> {
-            None
-        }
+    async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
+        (&mut **self).handle_event(control, event).await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ServiceHandle for Box<dyn ServiceHandle + Send + Sync + 'static> {
+    async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
+        (&mut **self).handle_error(control, error).await
     }
 
-    /// Session level protocol handle
-    #[async_trait::async_trait]
-    pub trait SessionProtocol: Send {
-        /// Called when opening protocol
-        async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
-        /// Called when closing protocol
-        async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
-        /// Called when the corresponding protocol message is received
-        async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
-        /// Called when the session receives the notify task
-        async fn notify(&mut self, _context: ProtocolContextMutRef<'_>, _token: u64) {}
-        /// Behave like `Stream::poll_next`, but nothing output
-        /// if ready with Some, it will continue poll immediately
-        /// if ready with None, it will don't try to call the function again
-        #[inline]
-        async fn poll(&mut self, _context: ProtocolContextMutRef<'_>) -> Option<()> {
-            None
-        }
+    async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
+        (&mut **self).handle_event(control, event).await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ServiceHandle for () {}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ServiceProtocol for Box<dyn ServiceProtocol + Send + 'static + Unpin> {
+    async fn init(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).init(context).await
     }
 
-    #[async_trait::async_trait]
-    impl ServiceHandle for Box<dyn ServiceHandle + Send + 'static> {
-        async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
-            (&mut **self).handle_error(control, error).await
-        }
-
-        async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
-            (&mut **self).handle_event(control, event).await
-        }
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
+        (&mut **self).connected(context, version).await
     }
 
-    #[async_trait::async_trait]
-    impl ServiceHandle for Box<dyn ServiceHandle + Send + Sync + 'static> {
-        async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
-            (&mut **self).handle_error(control, error).await
-        }
-
-        async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
-            (&mut **self).handle_event(control, event).await
-        }
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        (&mut **self).disconnected(context).await
     }
 
-    #[async_trait::async_trait]
-    impl ServiceHandle for () {}
-
-    #[async_trait::async_trait]
-    impl ServiceProtocol for Box<dyn ServiceProtocol + Send + 'static + Unpin> {
-        async fn init(&mut self, context: &mut ProtocolContext) {
-            (&mut **self).init(context).await
-        }
-
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        (&mut **self).received(context, data).await
     }
 
-    #[async_trait::async_trait]
-    impl ServiceProtocol for Box<dyn ServiceProtocol + Send + Sync + 'static + Unpin> {
-        async fn init(&mut self, context: &mut ProtocolContext) {
-            (&mut **self).init(context).await
-        }
-
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
+    async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+        (&mut **self).notify(context, token).await
     }
 
-    #[async_trait::async_trait]
-    impl SessionProtocol for Box<dyn SessionProtocol + Send + 'static + Unpin> {
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
+    #[inline]
+    async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
+        (&mut **self).poll(context).await
+    }
+}
 
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ServiceProtocol for Box<dyn ServiceProtocol + Send + Sync + 'static + Unpin> {
+    async fn init(&mut self, context: &mut ProtocolContext) {
+        (&mut **self).init(context).await
     }
 
-    #[async_trait::async_trait]
-    impl SessionProtocol for Box<dyn SessionProtocol + Send + Sync + 'static + Unpin> {
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
+        (&mut **self).connected(context, version).await
+    }
 
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        (&mut **self).disconnected(context).await
+    }
 
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        (&mut **self).received(context, data).await
+    }
 
-        async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
+    async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
+        (&mut **self).notify(context, token).await
+    }
 
-        #[inline]
-        async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
+    #[inline]
+    async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
+        (&mut **self).poll(context).await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SessionProtocol for Box<dyn SessionProtocol + Send + 'static + Unpin> {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
+        (&mut **self).connected(context, version).await
+    }
+
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        (&mut **self).disconnected(context).await
+    }
+
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        (&mut **self).received(context, data).await
+    }
+
+    async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
+        (&mut **self).notify(context, token).await
+    }
+
+    #[inline]
+    async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
+        (&mut **self).poll(context).await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SessionProtocol for Box<dyn SessionProtocol + Send + Sync + 'static + Unpin> {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
+        (&mut **self).connected(context, version).await
+    }
+
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        (&mut **self).disconnected(context).await
+    }
+
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        (&mut **self).received(context, data).await
+    }
+
+    async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
+        (&mut **self).notify(context, token).await
+    }
+
+    #[inline]
+    async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
+        (&mut **self).poll(context).await
     }
 }
 
@@ -275,224 +279,5 @@ impl Encoder<bytes::Bytes> for Box<dyn Codec + Send + 'static> {
 
     fn encode(&mut self, item: bytes::Bytes, dst: &mut bytes::BytesMut) -> Result<(), Self::Error> {
         Encoder::encode(&mut **self, item, dst)
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-mod inner {
-    use super::*;
-    /// Service handle
-    ///
-    /// #### Note
-    ///
-    /// All functions on this trait will block the entire server running, do not insert long-time tasks,
-    /// you can use the futures task instead.
-    ///
-    /// #### Behavior
-    ///
-    /// The handle that exists when the Service is created.
-    ///
-    /// Mainly handle some Service-level errors thrown at runtime, such as listening errors.
-    ///
-    /// At the same time, the session establishment and disconnection messages will also be perceived here.
-    #[async_trait::async_trait(?Send)]
-    pub trait ServiceHandle {
-        /// Handling runtime errors
-        async fn handle_error(&mut self, _control: &mut ServiceContext, _error: ServiceError) {}
-        /// Handling session establishment and disconnection events
-        async fn handle_event(&mut self, _control: &mut ServiceContext, _event: ServiceEvent) {}
-    }
-
-    /// Service level protocol handle
-    ///
-    /// #### Note
-    ///
-    /// All functions on this trait will block the entire server running, do not insert long-time tasks,
-    /// you can use the futures task instead.
-    ///
-    /// #### Behavior
-    ///
-    /// Define the behavior of each custom protocol in each state.
-    ///
-    /// Depending on whether the user defines a service handle or a session exclusive handle,
-    /// the runtime has different performance.
-    ///
-    /// The **important difference** is that some state values are allowed in the service handle,
-    /// and the handle exclusive to the session is "stateless", relative to the service handle,
-    /// it can only retain the information between a protocol stream on and off.
-    ///
-    /// The opening and closing of the protocol will create and clean up the handle exclusive
-    /// to the session, but the service handle will remain in the state until the service is closed.
-    ///
-    #[async_trait::async_trait(?Send)]
-    pub trait ServiceProtocol {
-        /// This function is called when the service start.
-        ///
-        /// The service handle will only be called once
-        async fn init(&mut self, context: &mut ProtocolContext);
-        /// Called when opening protocol
-        async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
-        /// Called when closing protocol
-        async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
-        /// Called when the corresponding protocol message is received
-        async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
-        /// Called when the Service receives the notify task
-        async fn notify(&mut self, _context: &mut ProtocolContext, _token: u64) {}
-        /// Behave like `Stream::poll_next`, but nothing output
-        /// if ready with Some, it will continue poll immediately
-        /// if ready with None, it will don't try to call the function again
-        #[inline]
-        async fn poll(&mut self, _context: &mut ProtocolContext) -> Option<()> {
-            None
-        }
-    }
-
-    /// Session level protocol handle
-    #[async_trait::async_trait(?Send)]
-    pub trait SessionProtocol {
-        /// Called when opening protocol
-        async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {}
-        /// Called when closing protocol
-        async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {}
-        /// Called when the corresponding protocol message is received
-        async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {}
-        /// Called when the session receives the notify task
-        async fn notify(&mut self, _context: ProtocolContextMutRef<'_>, _token: u64) {}
-        /// Behave like `Stream::poll_next`, but nothing output
-        /// if ready with Some, it will continue poll immediately
-        /// if ready with None, it will don't try to call the function again
-        #[inline]
-        async fn poll(&mut self, _context: ProtocolContextMutRef<'_>) -> Option<()> {
-            None
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl ServiceHandle for Box<dyn ServiceHandle + Send + 'static> {
-        async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
-            (&mut **self).handle_error(control, error).await
-        }
-
-        async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
-            (&mut **self).handle_event(control, event).await
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl ServiceHandle for Box<dyn ServiceHandle + Send + Sync + 'static> {
-        async fn handle_error(&mut self, control: &mut ServiceContext, error: ServiceError) {
-            (&mut **self).handle_error(control, error).await
-        }
-
-        async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
-            (&mut **self).handle_event(control, event).await
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl ServiceHandle for () {}
-
-    #[async_trait::async_trait(?Send)]
-    impl ServiceProtocol for Box<dyn ServiceProtocol + Send + 'static + Unpin> {
-        async fn init(&mut self, context: &mut ProtocolContext) {
-            (&mut **self).init(context).await
-        }
-
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl ServiceProtocol for Box<dyn ServiceProtocol + Send + Sync + 'static + Unpin> {
-        async fn init(&mut self, context: &mut ProtocolContext) {
-            (&mut **self).init(context).await
-        }
-
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: &mut ProtocolContext, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: &mut ProtocolContext) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl SessionProtocol for Box<dyn SessionProtocol + Send + 'static + Unpin> {
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
-    }
-
-    #[async_trait::async_trait(?Send)]
-    impl SessionProtocol for Box<dyn SessionProtocol + Send + Sync + 'static + Unpin> {
-        async fn connected(&mut self, context: ProtocolContextMutRef<'_>, version: &str) {
-            (&mut **self).connected(context, version).await
-        }
-
-        async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
-            (&mut **self).disconnected(context).await
-        }
-
-        async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
-            (&mut **self).received(context, data).await
-        }
-
-        async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
-            (&mut **self).notify(context, token).await
-        }
-
-        #[inline]
-        async fn poll(&mut self, context: ProtocolContextMutRef<'_>) -> Option<()> {
-            (&mut **self).poll(context).await
-        }
     }
 }

--- a/tentacle/tests/test_before_function.rs
+++ b/tentacle/tests/test_before_function.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -8,6 +8,7 @@ use std::{
     thread,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
@@ -34,23 +35,24 @@ where
 
 struct PHandle;
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "x".repeat(10);
-            let _res = context.send_message(Bytes::from(prefix));
+            let _res = context.send_message(Bytes::from(prefix)).await;
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: Bytes) {
         if context.session.ty.is_outbound() {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
@@ -101,7 +103,7 @@ fn test_before_handle(secio: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -120,7 +122,7 @@ fn test_before_handle(secio: bool) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_before_function.rs
+++ b/tentacle/tests/test_before_function.rs
@@ -102,11 +102,7 @@ fn test_before_handle(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -121,11 +117,7 @@ fn test_before_handle(secio: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     handle_2.join().unwrap();

--- a/tentacle/tests/test_block_future_task.rs
+++ b/tentacle/tests/test_block_future_task.rs
@@ -1,6 +1,7 @@
-use futures::{future::pending, StreamExt};
+use futures::future::pending;
 use std::time::Duration;
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::ProtocolContext,
     service::{ProtocolHandle, ProtocolMeta, Service},
@@ -23,21 +24,24 @@ struct PHandle {
     count: u8,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, context: &mut ProtocolContext) {
+    async fn init(&mut self, context: &mut ProtocolContext) {
         let proto_id = context.proto_id;
 
-        let _rse = context.set_service_notify(proto_id, Duration::from_millis(100), 1);
+        let _rse = context
+            .set_service_notify(proto_id, Duration::from_millis(100), 1)
+            .await;
 
         for _ in 0..4096 {
-            let _res = context.future_task(pending());
+            let _res = context.future_task(pending()).await;
         }
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
         self.count += 1;
         if self.count > 3 {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
@@ -59,7 +63,7 @@ fn test_block_future_task() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async move {
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/tests/test_block_future_task.rs
+++ b/tentacle/tests/test_block_future_task.rs
@@ -61,11 +61,5 @@ fn test_block_future_task() {
     let mut service = create(create_meta(1.into()), ());
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async move {
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
-    });
+    rt.block_on(async move { service.run().await });
 }

--- a/tentacle/tests/test_block_send.rs
+++ b/tentacle/tests/test_block_send.rs
@@ -148,11 +148,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -167,11 +163,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     handle_2.join().unwrap();

--- a/tentacle/tests/test_block_send.rs
+++ b/tentacle/tests/test_block_send.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -8,6 +8,7 @@ use std::{
     thread,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
@@ -36,59 +37,65 @@ struct PHandle {
     count: Arc<AtomicUsize>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "x".repeat(10);
             // NOTE: 256 is the send channel buffer size
             let length = 1024;
             for i in 0..length {
-                let _res = context.send_message(Bytes::from(format!("{}-{}", prefix, i)));
+                let _res = context
+                    .send_message(Bytes::from(format!("{}-{}", prefix, i)))
+                    .await;
             }
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: Bytes) {
         if context.session.ty.is_outbound() {
             self.count.fetch_add(1, Ordering::SeqCst);
         }
         let count_now = self.count.load(Ordering::SeqCst);
         if count_now == 1024 {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
 
+#[async_trait]
 impl SessionProtocol for PHandle {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "x".repeat(10);
             // NOTE: 256 is the send channel buffer size
             let length = 1024;
             for i in 0..length {
-                let _res = context.send_message(Bytes::from(format!("{}-{}", prefix, i)));
+                let _res = context
+                    .send_message(Bytes::from(format!("{}-{}", prefix, i)))
+                    .await;
             }
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: bytes::Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {
         if context.session.ty.is_outbound() {
             self.count.fetch_add(1, Ordering::SeqCst);
         }
         let count_now = self.count.load(Ordering::SeqCst);
         log::warn!("count_now: {}", count_now);
         if count_now == 1024 {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
@@ -142,7 +149,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -161,7 +168,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_block_send_session.rs
+++ b/tentacle/tests/test_block_send_session.rs
@@ -148,11 +148,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -167,11 +163,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     handle_2.join().unwrap();

--- a/tentacle/tests/test_block_send_session.rs
+++ b/tentacle/tests/test_block_send_session.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -8,6 +8,7 @@ use std::{
     thread,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
@@ -36,59 +37,65 @@ struct PHandle {
     count: Arc<AtomicUsize>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "x".repeat(10);
             // NOTE: 256 is the send channel buffer size
             let length = 1024;
             for i in 0..length {
-                let _res = context.send_message(Bytes::from(format!("{}-{}", prefix, i)));
+                let _res = context
+                    .send_message(Bytes::from(format!("{}-{}", prefix, i)))
+                    .await;
             }
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: Bytes) {
         if context.session.ty.is_outbound() {
             self.count.fetch_add(1, Ordering::SeqCst);
         }
         let count_now = self.count.load(Ordering::SeqCst);
         if count_now == 1024 {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
 
+#[async_trait]
 impl SessionProtocol for PHandle {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let prefix = "x".repeat(10);
             // NOTE: 256 is the send channel buffer size
             let length = 1024;
             for i in 0..length {
-                let _res = context.send_message(Bytes::from(format!("{}-{}", prefix, i)));
+                let _res = context
+                    .send_message(Bytes::from(format!("{}-{}", prefix, i)))
+                    .await;
             }
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, _data: bytes::Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {
         if context.session.ty.is_outbound() {
             self.count.fetch_add(1, Ordering::SeqCst);
         }
         let count_now = self.count.load(Ordering::SeqCst);
         log::warn!("count_now: {}", count_now);
         if count_now == 1024 {
-            let _res = context.shutdown();
+            let _res = context.shutdown().await;
         }
     }
 }
@@ -142,7 +149,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -161,7 +168,7 @@ fn test_block_send(secio: bool, session_protocol: bool) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_close.rs
+++ b/tentacle/tests/test_close.rs
@@ -141,11 +141,7 @@ fn test(secio: bool, shutdown: bool) {
 
             addr_sender.send(listen_addr).unwrap();
 
-            loop {
-                if service_1.run().await.is_none() {
-                    break;
-                }
-            }
+            service_1.run().await
         });
     });
 
@@ -178,11 +174,7 @@ where
                 .await
                 .unwrap();
 
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     })
 }

--- a/tentacle/tests/test_close.rs
+++ b/tentacle/tests/test_close.rs
@@ -1,5 +1,5 @@
-use futures::StreamExt;
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
@@ -35,31 +35,33 @@ struct PHandle {
     shutdown: bool,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
-        let _res = context.send_message(bytes::Bytes::from("hello"));
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
+        let _res = context.send_message(bytes::Bytes::from("hello")).await;
         if context.session.ty.is_inbound() && context.proto_id == 1.into() {
             self.count += 1;
             if self.count >= 4 {
-                let proto_id = context.proto_id;
-                let _res = context.set_service_notify(proto_id, Duration::from_millis(200), 0);
+                let _res = context
+                    .set_service_notify(context.proto_id, Duration::from_millis(200), 0)
+                    .await;
             }
         }
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
-        let _res = context.send_message(data);
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        let _res = context.send_message(data).await;
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
         self.count += 1;
         if self.count > 6 {
             if self.shutdown {
-                let _res = context.shutdown();
+                let _res = context.shutdown().await;
             } else {
-                let _res = context.close();
+                let _res = context.close().await;
             }
         }
     }
@@ -140,7 +142,7 @@ fn test(secio: bool, shutdown: bool) {
             addr_sender.send(listen_addr).unwrap();
 
             loop {
-                if service_1.next().await.is_none() {
+                if service_1.run().await.is_none() {
                     break;
                 }
             }
@@ -177,7 +179,7 @@ where
                 .unwrap();
 
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_dial.rs
+++ b/tentacle/tests/test_dial.rs
@@ -243,11 +243,7 @@ fn test_repeated_dial(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -262,11 +258,7 @@ fn test_repeated_dial(secio: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -296,13 +288,7 @@ fn test_dial_with_no_notify(secio: bool) {
     let control: ServiceControl = service.control().clone().into();
     thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
-        });
+        rt.block_on(async move { service.run().await });
     });
     // macOs can't dial 0 port
     for _ in 0..2 {

--- a/tentacle/tests/test_dial.rs
+++ b/tentacle/tests/test_dial.rs
@@ -1,17 +1,18 @@
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     thread,
     time::{Duration, Instant},
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     error::{DialerErrorKind, ListenErrorKind, TransportErrorKind},
     multiaddr::Multiaddr,
     secio::SecioKeyPair,
     service::{
-        ProtocolHandle, ProtocolMeta, Service, ServiceError, ServiceEvent, SessionType,
-        TargetProtocol,
+        ProtocolHandle, ProtocolMeta, Service, ServiceControl, ServiceError, ServiceEvent,
+        SessionType, TargetProtocol,
     },
     traits::{ServiceHandle, ServiceProtocol},
     ProtocolId, SessionId,
@@ -46,8 +47,9 @@ struct EmptySHandle {
     secio: bool,
 }
 
+#[async_trait]
 impl ServiceHandle for EmptySHandle {
-    fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
         use std::io;
 
         let error_type = if let ServiceError::DialerError { error, .. } = error {
@@ -71,8 +73,9 @@ pub struct SHandle {
     kind: SessionType,
 }
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
         let error_type = match error {
             ServiceError::DialerError { error, .. } => {
                 match error {
@@ -101,7 +104,7 @@ impl ServiceHandle for SHandle {
         let _res = self.sender.try_send(error_type);
     }
 
-    fn handle_event(&mut self, _env: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, _env: &mut ServiceContext, event: ServiceEvent) {
         if let ServiceEvent::SessionOpen { session_context } = event {
             self.session_id = session_context.id;
             self.kind = session_context.ty;
@@ -116,13 +119,16 @@ struct PHandle {
     dial_addr: Option<Multiaddr>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, context: &mut ProtocolContext) {
+    async fn init(&mut self, context: &mut ProtocolContext) {
         let proto_id = context.proto_id;
-        let _res = context.set_service_notify(proto_id, Duration::from_millis(100), 3);
+        let _res = context
+            .set_service_notify(proto_id, Duration::from_millis(100), 3)
+            .await;
     }
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             // if server, dial itself
             self.dial_addr = Some(context.listens()[0].clone());
@@ -133,16 +139,18 @@ impl ServiceProtocol for PHandle {
         self.connected_count += 1;
     }
 
-    fn disconnected(&mut self, _context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {
         self.connected_count -= 1;
     }
 
-    fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
+    async fn notify(&mut self, context: &mut ProtocolContext, _token: u64) {
         if self.dial_addr.is_some() {
-            let _res = context.dial(
-                self.dial_addr.as_ref().unwrap().clone(),
-                TargetProtocol::All,
-            );
+            let _res = context
+                .dial(
+                    self.dial_addr.as_ref().unwrap().clone(),
+                    TargetProtocol::All,
+                )
+                .await;
             self.dial_count += 1;
             if self.dial_count == 10 {
                 self.sender.try_send(self.connected_count).unwrap();
@@ -236,7 +244,7 @@ fn test_repeated_dial(secio: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -255,7 +263,7 @@ fn test_repeated_dial(secio: bool) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -285,12 +293,12 @@ fn test_dial_with_no_notify(secio: bool) {
     let (meta, _receiver) = create_meta(0.into());
     let (shandle, error_receiver) = create_shandle(secio, true);
     let mut service = create(secio, meta, shandle);
-    let control = service.control().clone();
+    let control: ServiceControl = service.control().clone().into();
     thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_disconnect.rs
+++ b/tentacle/tests/test_disconnect.rs
@@ -69,11 +69,7 @@ fn test_disconnect(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -87,11 +83,7 @@ fn test_disconnect(secio: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     thread::sleep(Duration::from_secs(5));

--- a/tentacle/tests/test_kill.rs
+++ b/tentacle/tests/test_kill.rs
@@ -120,11 +120,7 @@ fn test_kill(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     thread::sleep(Duration::from_millis(100));
@@ -159,11 +155,7 @@ fn test_kill(secio: bool) {
                     .dial(listen_addr, TargetProtocol::All)
                     .await
                     .unwrap();
-                loop {
-                    if service.run().await.is_none() {
-                        break;
-                    }
-                }
+                service.run().await
             });
         }
     }

--- a/tentacle/tests/test_kill.rs
+++ b/tentacle/tests/test_kill.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "linux")]
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use nix::{
     sys::signal::{kill, Signal},
     unistd::{fork, ForkResult},
@@ -8,11 +8,14 @@ use nix::{
 use std::{thread, time::Duration};
 use systemstat::{Platform, System};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
     secio::SecioKeyPair,
-    service::{ProtocolHandle, ProtocolMeta, Service, TargetProtocol, TargetSession},
+    service::{
+        ProtocolHandle, ProtocolMeta, Service, ServiceControl, TargetProtocol, TargetSession,
+    },
     traits::{ServiceHandle, ServiceProtocol},
     ProtocolId,
 };
@@ -60,22 +63,24 @@ struct PHandle {
     sender: crossbeam_channel::Sender<()>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, _context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, _context: ProtocolContextMutRef<'_>, _version: &str) {
         self.connected_count += 1;
         assert_eq!(self.sender.send(()), Ok(()));
     }
 
-    fn disconnected(&mut self, _context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, _context: ProtocolContextMutRef<'_>) {
         self.connected_count -= 1;
         assert_eq!(self.sender.send(()), Ok(()));
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
-        let proto_id = context.proto_id;
-        let _res = context.filter_broadcast(TargetSession::All, proto_id, data);
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
+        let _res = context
+            .filter_broadcast(TargetSession::All, context.proto_id, data)
+            .await;
     }
 }
 
@@ -106,7 +111,7 @@ fn test_kill(secio: bool) {
     let (meta, receiver) = create_meta(1.into());
     let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
     let mut service = create(secio, meta, ());
-    let control = service.control().clone();
+    let control: ServiceControl = service.control().clone().into();
     thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
@@ -116,7 +121,7 @@ fn test_kill(secio: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -155,7 +160,7 @@ fn test_kill(secio: bool) {
                     .await
                     .unwrap();
                 loop {
-                    if service.next().await.is_none() {
+                    if service.run().await.is_none() {
                         break;
                     }
                 }

--- a/tentacle/tests/test_large_pending_messge.rs
+++ b/tentacle/tests/test_large_pending_messge.rs
@@ -1,7 +1,8 @@
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::thread;
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     multiaddr::Multiaddr,
@@ -31,19 +32,20 @@ where
 
 struct PHandle;
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             let data = Bytes::from(vec![0; 1024 * 1024 * 8]);
             loop {
-                let _res = context.send_message(data.clone());
+                let _res = context.send_message(data.clone()).await;
             }
         }
     }
 
-    fn received(&mut self, _context: ProtocolContextMutRef, _data: bytes::Bytes) {
+    async fn received(&mut self, _context: ProtocolContextMutRef<'_>, _data: bytes::Bytes) {
         thread::sleep(::std::time::Duration::from_secs(10));
     }
 }
@@ -65,8 +67,9 @@ fn create_meta(id: ProtocolId) -> ProtocolMeta {
 #[derive(Clone)]
 pub struct SHandle;
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_error(&mut self, _control: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _control: &mut ServiceContext, error: ServiceError) {
         match error {
             ServiceError::SessionBlocked { .. } => (),
             e => panic!("Unexpected error: {:?}", e),
@@ -88,7 +91,7 @@ fn test_large_message(secio: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -105,7 +108,7 @@ fn test_large_message(secio: bool) {
             .await
             .unwrap();
         loop {
-            if service.next().await.is_none() {
+            if service.run().await.is_none() {
                 break;
             }
         }

--- a/tentacle/tests/test_large_pending_messge.rs
+++ b/tentacle/tests/test_large_pending_messge.rs
@@ -90,11 +90,7 @@ fn test_large_message(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -107,11 +103,7 @@ fn test_large_message(secio: bool) {
             .dial(listen_addr, TargetProtocol::All)
             .await
             .unwrap();
-        loop {
-            if service.run().await.is_none() {
-                break;
-            }
-        }
+        service.run().await
     });
 }
 

--- a/tentacle/tests/test_peer_id.rs
+++ b/tentacle/tests/test_peer_id.rs
@@ -109,11 +109,7 @@ fn test_peer_id(fail: bool) {
 
             addr_sender.send(listen_addr).unwrap();
 
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -125,13 +121,7 @@ fn test_peer_id(fail: bool) {
     let control: ServiceControl = service.control().clone().into();
     thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async move {
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
-        });
+        rt.block_on(async move { service.run().await });
     });
 
     if fail {

--- a/tentacle/tests/test_peer_id.rs
+++ b/tentacle/tests/test_peer_id.rs
@@ -1,13 +1,16 @@
-use futures::StreamExt;
 use std::{borrow::Cow, sync::mpsc::channel, thread};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ServiceContext},
     error::DialerErrorKind,
     multiaddr::Multiaddr,
     multiaddr::Protocol as MultiProtocol,
     secio::SecioKeyPair,
-    service::{ProtocolHandle, ProtocolMeta, Service, ServiceError, ServiceEvent, TargetProtocol},
+    service::{
+        ProtocolHandle, ProtocolMeta, Service, ServiceControl, ServiceError, ServiceEvent,
+        TargetProtocol,
+    },
     traits::{ServiceHandle, ServiceProtocol},
     ProtocolId,
 };
@@ -25,8 +28,9 @@ where
 
 struct PHandle;
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _control: &mut ProtocolContext) {}
+    async fn init(&mut self, _control: &mut ProtocolContext) {}
 }
 
 #[derive(Clone)]
@@ -35,8 +39,9 @@ struct EmptySHandle {
     error_count: usize,
 }
 
+#[async_trait]
 impl ServiceHandle for EmptySHandle {
-    fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
+    async fn handle_error(&mut self, _env: &mut ServiceContext, error: ServiceError) {
         self.error_count += 1;
 
         if let ServiceError::DialerError { error, .. } = error {
@@ -56,7 +61,7 @@ impl ServiceHandle for EmptySHandle {
         }
     }
 
-    fn handle_event(&mut self, _control: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, _control: &mut ServiceContext, event: ServiceEvent) {
         if let ServiceEvent::SessionOpen { .. } = event {
             let _res = self.sender.try_send(self.error_count);
         }
@@ -105,7 +110,7 @@ fn test_peer_id(fail: bool) {
             addr_sender.send(listen_addr).unwrap();
 
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -117,12 +122,12 @@ fn test_peer_id(fail: bool) {
     let (shandle, error_receiver) = create_shandle();
     let meta = create_meta(1.into());
     let mut service = create(SecioKeyPair::secp256k1_generated(), meta, shandle);
-    let control = service.control().clone();
+    let control: ServiceControl = service.control().clone().into();
     thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async move {
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_priority.rs
+++ b/tentacle/tests/test_priority.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -8,6 +8,7 @@ use std::{
     thread,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef},
     multiaddr::Multiaddr,
@@ -39,21 +40,22 @@ struct PHandle {
     test_result: Arc<AtomicBool>,
 }
 
+#[async_trait]
 impl ServiceProtocol for PHandle {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             for i in 0..1024 {
                 if i == 254 {
-                    let _res = context.quick_send_message(Bytes::from("high"));
+                    let _res = context.quick_send_message(Bytes::from("high")).await;
                 }
-                let _res = context.send_message(Bytes::from("normal"));
+                let _res = context.send_message(Bytes::from("normal")).await;
             }
         }
     }
 
-    fn received(&mut self, context: ProtocolContextMutRef, data: bytes::Bytes) {
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, data: bytes::Bytes) {
         self.count += 1;
         if data == Bytes::from("high") {
             // We are not sure that the message was sent in the first few,
@@ -61,7 +63,7 @@ impl ServiceProtocol for PHandle {
             if self.count <= 255 {
                 self.test_result.store(true, Ordering::SeqCst);
             }
-            let _res = context.close();
+            let _res = context.close().await;
         }
     }
 }
@@ -99,7 +101,7 @@ fn test_priority(secio: bool, addr: &'static str) {
             let listen_addr = service.listen(addr.parse().unwrap()).await.unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -118,7 +120,7 @@ fn test_priority(secio: bool, addr: &'static str) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_priority.rs
+++ b/tentacle/tests/test_priority.rs
@@ -100,11 +100,7 @@ fn test_priority(secio: bool, addr: &'static str) {
         rt.block_on(async move {
             let listen_addr = service.listen(addr.parse().unwrap()).await.unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -119,11 +115,7 @@ fn test_priority(secio: bool, addr: &'static str) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     handle_1.join().unwrap();

--- a/tentacle/tests/test_protocol_open.rs
+++ b/tentacle/tests/test_protocol_open.rs
@@ -125,11 +125,7 @@ fn test_protocol_open(secio: bool) {
                 .await
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
 
@@ -144,11 +140,7 @@ fn test_protocol_open(secio: bool) {
                 .dial(listen_addr, TargetProtocol::All)
                 .await
                 .unwrap();
-            loop {
-                if service.run().await.is_none() {
-                    break;
-                }
-            }
+            service.run().await
         });
     });
     handle_2.join().unwrap();

--- a/tentacle/tests/test_protocol_open.rs
+++ b/tentacle/tests/test_protocol_open.rs
@@ -1,4 +1,4 @@
-use futures::{channel, StreamExt};
+use futures::channel;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::ProtocolContextMutRef,
     multiaddr::Multiaddr,
@@ -37,37 +38,44 @@ struct PHandle {
     count: Arc<AtomicUsize>,
 }
 
+#[async_trait]
 impl SessionProtocol for PHandle {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
-        let _res = context.set_session_notify(
-            context.session.id,
-            context.proto_id,
-            Duration::from_millis(300),
-            1,
-        );
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
+        let _res = context
+            .set_session_notify(
+                context.session.id,
+                context.proto_id,
+                Duration::from_millis(300),
+                1,
+            )
+            .await;
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
-        let _res = context.shutdown();
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
     }
 
-    fn notify(&mut self, context: ProtocolContextMutRef, token: u64) {
+    async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
         match token {
             1 => {
                 self.count_close += 1;
                 if self.count_close > 10 {
-                    let _res = context.shutdown();
+                    let _res = context.shutdown().await;
                 } else if self.count_close > 3 {
                     // 1. open protocol
                     // 2. set another notify
                     // 3. must notify same session protocol handle
-                    let _res = context.open_protocol(context.session.id, context.proto_id);
-                    let _res = context.set_session_notify(
-                        context.session.id,
-                        context.proto_id,
-                        Duration::from_millis(300),
-                        2,
-                    );
+                    let _res = context
+                        .open_protocol(context.session.id, context.proto_id)
+                        .await;
+                    let _res = context
+                        .set_session_notify(
+                            context.session.id,
+                            context.proto_id,
+                            Duration::from_millis(300),
+                            2,
+                        )
+                        .await;
                 }
             }
             2 => {
@@ -118,7 +126,7 @@ fn test_protocol_open(secio: bool) {
                 .unwrap();
             let _res = addr_sender.send(listen_addr);
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }
@@ -137,7 +145,7 @@ fn test_protocol_open(secio: bool) {
                 .await
                 .unwrap();
             loop {
-                if service.next().await.is_none() {
+                if service.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_protocol_open_close_on_spawn.rs
+++ b/tentacle/tests/test_protocol_open_close_on_spawn.rs
@@ -160,11 +160,7 @@ fn test_session_proto_open_close(secio: bool) {
 
             addr_sender.send(listen_addr).unwrap();
 
-            loop {
-                if service_2.run().await.is_none() {
-                    break;
-                }
-            }
+            service_2.run().await
         });
     });
 
@@ -178,11 +174,7 @@ fn test_session_proto_open_close(secio: bool) {
                 .await
                 .unwrap();
 
-            loop {
-                if service_1.run().await.is_none() {
-                    break;
-                }
-            }
+            service_1.run().await
         });
     });
 

--- a/tentacle/tests/test_protocol_open_close_on_spawn.rs
+++ b/tentacle/tests/test_protocol_open_close_on_spawn.rs
@@ -32,11 +32,12 @@ impl ProtocolSpawn for Dummy {
     fn spawn(
         &self,
         context: Arc<SessionContext>,
-        control: &ServiceControl,
+        control: &ServiceAsyncControl,
         _read_part: SubstreamReadPart,
     ) {
         // dummy open the test protocol
-        control.open_protocol(context.id, 1.into()).unwrap()
+        let c: ServiceControl = control.clone().into();
+        c.open_protocol(context.id, 1.into()).unwrap()
         // protocol close here
     }
 }
@@ -50,7 +51,7 @@ impl ProtocolSpawn for PHandle {
     fn spawn(
         &self,
         context: Arc<SessionContext>,
-        control: &ServiceControl,
+        control: &ServiceAsyncControl,
         mut read_part: SubstreamReadPart,
     ) {
         let id = context.id;
@@ -59,7 +60,7 @@ impl ProtocolSpawn for PHandle {
 
         if is_outbound && self.once.load(Ordering::Relaxed) {
             self.once.store(false, Ordering::Relaxed);
-            let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+            let control = control.clone();
 
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval_at(
@@ -74,7 +75,7 @@ impl ProtocolSpawn for PHandle {
         }
 
         if is_outbound {
-            let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+            let control = control.clone();
 
             tokio::spawn(async move {
                 control.close_protocol(id, pid).await.unwrap();
@@ -82,7 +83,7 @@ impl ProtocolSpawn for PHandle {
         }
 
         let count = self.count.clone();
-        let mut control = Into::<ServiceAsyncControl>::into(control.clone());
+        let control = control.clone();
         tokio::spawn(async move {
             while let Some(Ok(_)) = read_part.next().await {}
             if is_outbound {
@@ -160,7 +161,7 @@ fn test_session_proto_open_close(secio: bool) {
             addr_sender.send(listen_addr).unwrap();
 
             loop {
-                if service_2.next().await.is_none() {
+                if service_2.run().await.is_none() {
                     break;
                 }
             }
@@ -178,7 +179,7 @@ fn test_session_proto_open_close(secio: bool) {
                 .unwrap();
 
             loop {
-                if service_1.next().await.is_none() {
+                if service_1.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_session_handle_open.rs
+++ b/tentacle/tests/test_session_handle_open.rs
@@ -1,6 +1,6 @@
-use futures::StreamExt;
 use std::{sync::mpsc::channel, thread};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::{ProtocolContext, ProtocolContextMutRef, ServiceContext},
     multiaddr::Multiaddr,
@@ -20,19 +20,21 @@ use tentacle::{
 #[derive(Clone)]
 struct PHandle;
 
+#[async_trait]
 impl SessionProtocol for PHandle {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_inbound() {
             // Close the session after opening the protocol correctly
-            let _res = context.disconnect(context.session.id);
+            let _res = context.disconnect(context.session.id).await;
         }
     }
 }
 
 struct Dummy;
 
+#[async_trait]
 impl ServiceProtocol for Dummy {
-    fn init(&mut self, _context: &mut ProtocolContext) {}
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
 }
 
 struct SHandle {
@@ -40,22 +42,27 @@ struct SHandle {
     addr: Option<Multiaddr>,
 }
 
+#[async_trait]
 impl ServiceHandle for SHandle {
-    fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
+    async fn handle_event(&mut self, control: &mut ServiceContext, event: ServiceEvent) {
         if let ServiceEvent::SessionOpen { session_context } = event {
             self.addr = Some(session_context.address.clone());
             if session_context.ty.is_outbound() {
-                control.open_protocol(session_context.id, 1.into()).unwrap();
+                control
+                    .open_protocol(session_context.id, 1.into())
+                    .await
+                    .unwrap();
             }
         } else if let ServiceEvent::SessionClose { session_context } = event {
             // Test ends after 10 connections and opening session protocol
             if session_context.ty.is_outbound() {
                 self.count += 1;
                 if self.count >= 10 {
-                    control.shutdown().unwrap();
+                    control.shutdown().await.unwrap();
                 } else {
-                    let _res =
-                        control.dial(self.addr.clone().unwrap(), TargetProtocol::Single(0.into()));
+                    let _res = control
+                        .dial(self.addr.clone().unwrap(), TargetProtocol::Single(0.into()))
+                        .await;
                 }
             }
         }
@@ -141,7 +148,7 @@ fn test_session_handle_open(secio: bool) {
             addr_sender.send(listen_addr).unwrap();
 
             loop {
-                if service_2.next().await.is_none() {
+                if service_2.run().await.is_none() {
                     break;
                 }
             }
@@ -159,7 +166,7 @@ fn test_session_handle_open(secio: bool) {
                 .unwrap();
 
             loop {
-                if service_1.next().await.is_none() {
+                if service_1.run().await.is_none() {
                     break;
                 }
             }

--- a/tentacle/tests/test_session_handle_open.rs
+++ b/tentacle/tests/test_session_handle_open.rs
@@ -147,11 +147,7 @@ fn test_session_handle_open(secio: bool) {
 
             addr_sender.send(listen_addr).unwrap();
 
-            loop {
-                if service_2.run().await.is_none() {
-                    break;
-                }
-            }
+            service_2.run().await
         });
     });
 
@@ -165,11 +161,7 @@ fn test_session_handle_open(secio: bool) {
                 .await
                 .unwrap();
 
-            loop {
-                if service_1.run().await.is_none() {
-                    break;
-                }
-            }
+            service_1.run().await
         });
     });
 

--- a/tentacle/tests/test_session_protocol_open_close.rs
+++ b/tentacle/tests/test_session_protocol_open_close.rs
@@ -146,11 +146,7 @@ fn test_session_proto_open_close(secio: bool) {
 
             addr_sender.send(listen_addr).unwrap();
 
-            loop {
-                if service_2.run().await.is_none() {
-                    break;
-                }
-            }
+            service_2.run().await
         });
     });
 
@@ -164,11 +160,7 @@ fn test_session_proto_open_close(secio: bool) {
                 .await
                 .unwrap();
 
-            loop {
-                if service_1.run().await.is_none() {
-                    break;
-                }
-            }
+            service_1.run().await
         });
     });
 

--- a/tentacle/tests/test_session_protocol_open_close.rs
+++ b/tentacle/tests/test_session_protocol_open_close.rs
@@ -1,6 +1,6 @@
-use futures::StreamExt;
 use std::{sync::mpsc::channel, thread, time::Duration};
 use tentacle::{
+    async_trait,
     builder::{MetaBuilder, ServiceBuilder},
     context::ProtocolContextMutRef,
     multiaddr::Multiaddr,
@@ -18,10 +18,14 @@ use tentacle::{
 #[derive(Clone)]
 struct Dummy;
 
+#[async_trait]
 impl SessionProtocol for Dummy {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         // dummy open the test protocol
-        context.open_protocol(context.session.id, 1.into()).unwrap();
+        context
+            .open_protocol(context.session.id, 1.into())
+            .await
+            .unwrap();
     }
 }
 
@@ -30,12 +34,14 @@ struct PHandle {
     count: usize,
 }
 
+#[async_trait]
 impl SessionProtocol for PHandle {
-    fn connected(&mut self, context: ProtocolContextMutRef, _version: &str) {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
         if context.session.ty.is_outbound() {
             // close self protocol
             context
                 .close_protocol(context.session.id, context.proto_id)
+                .await
                 .unwrap();
             // set a timer to open self protocol
             // because service state may not clean
@@ -46,24 +52,26 @@ impl SessionProtocol for PHandle {
                     Duration::from_millis(100),
                     1,
                 )
+                .await
                 .unwrap();
         }
     }
 
-    fn disconnected(&mut self, context: ProtocolContextMutRef) {
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
         if context.session.ty.is_outbound() {
             // each close add one
             self.count += 1;
             if self.count >= 10 {
-                let _ignore = context.shutdown();
+                let _ignore = context.shutdown().await;
             }
         }
     }
 
-    fn notify(&mut self, context: ProtocolContextMutRef, _token: u64) {
+    async fn notify(&mut self, context: ProtocolContextMutRef<'_>, _token: u64) {
         // try open self with remote
         context
             .open_protocol(context.session.id, context.proto_id)
+            .await
             .unwrap();
     }
 }
@@ -139,7 +147,7 @@ fn test_session_proto_open_close(secio: bool) {
             addr_sender.send(listen_addr).unwrap();
 
             loop {
-                if service_2.next().await.is_none() {
+                if service_2.run().await.is_none() {
                     break;
                 }
             }
@@ -157,7 +165,7 @@ fn test_session_proto_open_close(secio: bool) {
                 .unwrap();
 
             loop {
-                if service_1.next().await.is_none() {
+                if service_1.run().await.is_none() {
                     break;
                 }
             }


### PR DESCRIPTION
ref #305 

This PR achieves a complete migration to the async trait, users can write code in async env

`tentacle/src/traits.rs` is the core of the modification
`tentacle/src/channel/bound.rs` Channels adds two async methods that do not use mut to facilitate the uniformity of the user interface and avoid unnecessary mut marks 
`tentacle/src/protocol_handle_stream.rs` and `tentacle/src/service.rs` as the place to inherit the implementation of the user’s async trait, part of the logic is inevitably rewritten 

Other changes are due to the changes caused by the above changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nervosnetwork/tentacle/323)
<!-- Reviewable:end -->
