### PR TITLE
fix: yamux window update bug

### DIFF
--- a/yamux/src/config.rs
+++ b/yamux/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
 
     /// MaxStreamWindowSize is used to control the maximum
     /// window size that we allow for a stream.
+    /// Must be greater than or equal to 256 * 1024
     pub max_stream_window_size: u32,
 }
 

--- a/yamux/src/frame.rs
+++ b/yamux/src/frame.rs
@@ -293,7 +293,7 @@ impl Decoder for FrameCodec {
                 let flags = Flags(header_data.get_u16());
                 let stream_id = header_data.get_u32();
                 let length = header_data.get_u32();
-                if length > self.max_frame_size {
+                if ty == Type::Data && length > self.max_frame_size {
                     let err = io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("yamux.length={}", length),


### PR DESCRIPTION
There are two problems here, which cause yamux to fail to increase the default window normally:

1. From [spec](https://github.com/hashicorp/yamux/blob/0bc27b27de87381b58e35462a8dcbd69040279c1/spec.md#flow-control), stream init window size must be 256kb
2. Codec only needs to judge the size of length when it is of data type, to return in advance 


The above modification does not affect the behavior under the default configuration but affects the user configuration behavior 

**Warng: If you need to adjust the window size, please update all application dependencies in time**

