### PR TITLE
chore: add cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Cargo.lock
 **/pkg/
 **/**/www/node_modules/
 **/**/www/package-lock.json
+tentacle-cov/

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -548,11 +548,7 @@ impl Session {
             SessionEvent::ProtocolMessage { proto_id, data, .. } => {
                 if let Some(stream_id) = self.proto_streams.get(&proto_id) {
                     if let Some(buffer) = self.substreams.get_mut(stream_id) {
-                        let event = ProtocolEvent::Message {
-                            id: *stream_id,
-                            proto_id,
-                            data,
-                        };
+                        let event = ProtocolEvent::Message { data };
                         if priority.is_high() {
                             buffer.push_high(event)
                         } else {

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -43,10 +43,6 @@ pub(crate) enum ProtocolEvent {
     },
     /// Protocol data outbound and inbound
     Message {
-        /// Stream id
-        id: StreamId,
-        /// Protocol id
-        proto_id: ProtocolId,
         /// Data
         data: bytes::Bytes,
     },
@@ -55,8 +51,6 @@ pub(crate) enum ProtocolEvent {
     },
     /// Codec error
     Error {
-        /// Stream id
-        id: StreamId,
         /// Protocol id
         proto_id: ProtocolId,
         /// Codec error
@@ -249,7 +243,6 @@ where
             _ => (),
         }
         self.event_sender.push(ProtocolEvent::Error {
-            id: self.id,
             proto_id: self.proto_id,
             error,
         });
@@ -259,7 +252,7 @@ where
     /// Handling commands send by session
     fn handle_proto_event(&mut self, cx: &mut Context, event: ProtocolEvent, priority: Priority) {
         match event {
-            ProtocolEvent::Message { data, .. } => {
+            ProtocolEvent::Message { data } => {
                 self.push_back(priority, data);
 
                 if let Err(err) = self.send_data(cx) {
@@ -273,7 +266,6 @@ where
                     self.output_event(
                         cx,
                         ProtocolEvent::Error {
-                            id: self.id,
                             proto_id: self.proto_id,
                             error: err,
                         },
@@ -708,7 +700,7 @@ where
     /// Handling commands send by session
     fn handle_proto_event(&mut self, cx: &mut Context, event: ProtocolEvent, priority: Priority) {
         match event {
-            ProtocolEvent::Message { data, .. } => {
+            ProtocolEvent::Message { data } => {
                 self.push_back(priority, data);
 
                 if let Err(err) = self.send_data(cx) {
@@ -722,7 +714,6 @@ where
                     self.output_event(
                         cx,
                         ProtocolEvent::Error {
-                            id: self.id,
                             proto_id: self.proto_id,
                             error: err,
                         },
@@ -776,7 +767,6 @@ where
             _ => (),
         }
         self.event_sender.push(ProtocolEvent::Error {
-            id: self.id,
             proto_id: self.proto_id,
             error,
         });

--- a/tentacle/tests/test_dial.rs
+++ b/tentacle/tests/test_dial.rs
@@ -44,7 +44,6 @@ enum ServiceErrorType {
 #[derive(Clone)]
 struct EmptySHandle {
     sender: crossbeam_channel::Sender<ServiceErrorType>,
-    secio: bool,
 }
 
 #[async_trait]
@@ -194,7 +193,7 @@ fn create_shandle(
     let (sender, receiver) = crossbeam_channel::unbounded();
 
     if empty {
-        (Box::new(EmptySHandle { sender, secio }), receiver)
+        (Box::new(EmptySHandle { sender }), receiver)
     } else {
         (
             Box::new(SHandle {

--- a/tentacle/tests/test_tls_dial.rs
+++ b/tentacle/tests/test_tls_dial.rs
@@ -50,7 +50,6 @@ enum ServiceErrorType {
 #[derive(Clone)]
 pub struct SHandle {
     sender: crossbeam_channel::Sender<ServiceErrorType>,
-    tls: bool,
     session_id: SessionId,
     kind: SessionType,
 }
@@ -157,9 +156,7 @@ fn create_meta(id: ProtocolId) -> (ProtocolMeta, crossbeam_channel::Receiver<byt
     (meta, receiver)
 }
 
-fn create_shandle(
-    tls: bool,
-) -> (
+fn create_shandle() -> (
     Box<dyn ServiceHandle + Send>,
     crossbeam_channel::Receiver<ServiceErrorType>,
 ) {
@@ -169,7 +166,6 @@ fn create_shandle(
     (
         Box::new(SHandle {
             sender,
-            tls,
             session_id: 0.into(),
             kind: SessionType::Inbound,
         }),
@@ -362,7 +358,7 @@ pub fn make_client_config(config: &NetConfig) -> ClientConfig {
 fn test_tls_dial() {
     let (meta_1, receiver_1) = create_meta(1.into());
     let (meta_2, receiver_2) = create_meta(1.into());
-    let (shandle, _error_receiver_1) = create_shandle(true);
+    let (shandle, _error_receiver_1) = create_shandle();
     let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
 
     thread::spawn(move || {
@@ -379,7 +375,7 @@ fn test_tls_dial() {
         });
     });
 
-    let (shandle, _error_receiver_2) = create_shandle(true);
+    let (shandle, _error_receiver_2) = create_shandle();
 
     thread::spawn(move || {
         let _multi_addr_2 = Multiaddr::from_str(


### PR DESCRIPTION
Command to increase statistical test coverage, although it is a bit inaccurate

After `make cov`, an HTML display will be generated in the `tentacle-cov` directory, which can be opened directly through the browser 

![image](https://user-images.githubusercontent.com/19374080/144016398-b5a0357b-73cd-4ad5-bcef-391da66fe8bf.png)

