### PR TITLE
chore: lower loglevel of scheduling logs

### DIFF
--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -529,7 +529,7 @@ where
 
     // Receive frames from low level stream
     fn recv_frames(&mut self, cx: &mut Context) -> Poll<Option<Result<(), io::Error>>> {
-        debug!("[{:?}] poll from framed_stream", self.ty);
+        trace!("[{:?}] poll from framed_stream", self.ty);
         match Pin::new(&mut self.framed_stream).as_mut().poll_next(cx) {
             Poll::Ready(Some(Ok(frame))) => {
                 self.handle_frame(cx, frame)?;
@@ -540,7 +540,7 @@ where
                 Poll::Ready(None)
             }
             Poll::Pending => {
-                debug!("[{:?}] poll framed_stream NotReady", self.ty);
+                trace!("[{:?}] poll framed_stream NotReady", self.ty);
                 Poll::Pending
             }
             Poll::Ready(Some(Err(err))) => {


### PR DESCRIPTION
Scheduling logging is high frequency and only useful when debugging p2p schedulers. Most of the time, users don't care about scheduling details. I therefore lower its log-level to `Trace`.