### PR TITLE
feat: re-add multi to target session

### DIFF
--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -227,8 +227,10 @@ pub enum TargetSession {
     All,
     /// Try send to only one
     Single(SessionId),
+    /// Try send to some determined session
+    Multi(Box<dyn Iterator<Item = SessionId> + Send + 'static>),
     /// Try send to some session, if return true, send to it
-    Filter(Box<dyn Fn(&SessionId) -> bool + Sync + Send + 'static>),
+    Filter(Box<dyn FnMut(&SessionId) -> bool + Send + 'static>),
 }
 
 impl From<SessionId> for TargetSession {


### PR DESCRIPTION
ref #305 

After a period of online testing and use, we found that we needed to add back `Multi`

The current methods of sending messages can be divided into two main categories: 
1. sending with a specified id (Single, Multi)
2. send all (All, Filter)

For multicast where the specified object is known, using `Filter` is a costly act and a full traversal of all connected nodes must be performed.

`Filter` is more suitable for behaviors where the specific target is not known, but the sending rules are known, such as [gossip](https://github.com/nervosnetwork/axon/blob/main/core/network/src/outbound/gossip.rs#L166)

Now there is one more problem, do we need to specify `Vec` or the more loose `Box<dyn Iterator<Item = SessionId> + Send + 'static>` as the type of `Multi`？ @TheWaWaR @quake 
