### PR TITLE
chore: bump to 0.4.0-beta5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Features check
         run: |
+          echo "stable" > rust-toolchain
           rustup target add wasm32-unknown-unknown
           make features-check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0-beta.5
+
+### Features
+- Re-add multi to target session(#352)
+
 ## secio 0.5.4
 
 ### Features

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle"
-version = "0.4.0-beta.4"
+version = "0.4.0-beta.5"
 license = "MIT"
 description = "Minimal implementation for a multiplexed p2p network framework."
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]
@@ -66,7 +66,7 @@ env_logger = "0.6.0"
 crossbeam-channel = "0.5"
 systemstat = "0.1.3"
 futures-test = "0.3.5"
-rustls-pemfile = "0.3"
+rustls-pemfile = "1"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.24.1", default-features = false, features = ["signal"] }


### PR DESCRIPTION
It looks like this should be the last beta before the official release, and no API change requirements have been found so far