### PR TITLE
fix: Fix bug

### DIFF
--- a/tentacle/src/builder.rs
+++ b/tentacle/src/builder.rs
@@ -181,7 +181,14 @@ impl ServiceBuilder {
     ///      socket.set_reuse_address(true)?;
     ///      socket.bind(&"127.0.0.1:1080".parse::<SocketAddr>().unwrap().into())?;
     ///      socket.set_keepalive(true)?;
-    ///      Ok(socket.into())
+    ///      let socket = unsafe {
+    ///         #[cfg(unix)]
+    ///         let socket = TcpSocket::from_raw_fd(socket.into_raw_fd());
+    ///         #[cfg(windows)]
+    ///         let socket = TcpSocket::from_raw_socket(socket.into_raw_socket());
+    ///         socket
+    ///      };
+    ///      Ok(socket)
     /// });
     /// ```
     ///

--- a/tentacle/src/protocol_handle_stream.rs
+++ b/tentacle/src/protocol_handle_stream.rs
@@ -1,5 +1,6 @@
 use futures::{
     channel::{mpsc, oneshot},
+    future::poll_fn,
     SinkExt, StreamExt,
 };
 use log::{debug, trace};
@@ -232,6 +233,7 @@ where
                 self.current_task.idle();
                 break;
             }
+            poll_fn(|cx| crate::runtime::poll_proceed(cx)).await;
             tokio::select! {
                 event = self.receiver.next() => {
                     match event {
@@ -441,6 +443,7 @@ where
 
     pub async fn run(&mut self, mut recv: oneshot::Receiver<()>) {
         loop {
+            poll_fn(|cx| crate::runtime::poll_proceed(cx)).await;
             tokio::select! {
                 event = self.receiver.next() => {
                     match event {

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_arch = "wasm32"))]
-pub use async_std::task::{spawn, spawn_blocking, JoinHandle};
+pub use async_std::task::{spawn, spawn_blocking, JoinHandle, yield_now};
 
 pub fn block_in_place<F, R>(f: F) -> R
 where

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -13,7 +13,10 @@ pub use os::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod os {
-    use crate::{runtime::CompatStream2, service::config::TcpSocketConfig};
+    use crate::{
+        runtime::CompatStream2,
+        service::config::{TcpSocket, TcpSocketConfig},
+    };
     use async_io::Async;
     use async_std::net::{TcpListener as AsyncListener, TcpStream as AsyncStream, ToSocketAddrs};
     use futures::{
@@ -142,7 +145,7 @@ mod os {
         let socket = Socket::new(domain, Type::STREAM, Some(SocketProtocol::TCP))?;
 
         let socket = {
-            let t = tcp_config(socket.into())?;
+            let t = tcp_config(TcpSocket { inner: socket })?;
             t.inner
         };
         // `bind` twice will return error
@@ -181,7 +184,7 @@ mod os {
             // user can disable it on tcp_config
             #[cfg(not(windows))]
             socket.set_reuse_address(true)?;
-            let t = tcp_config(socket.into())?;
+            let t = tcp_config(TcpSocket { inner: socket })?;
             t.inner
         };
 

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_arch = "wasm32"))]
-pub use async_std::task::{spawn, spawn_blocking, JoinHandle, yield_now};
+pub use async_std::task::{spawn, spawn_blocking, yield_now, JoinHandle};
 
 pub fn block_in_place<F, R>(f: F) -> R
 where

--- a/tentacle/src/runtime/budget.rs
+++ b/tentacle/src/runtime/budget.rs
@@ -1,0 +1,67 @@
+//! Since tokio does not make the coop module public, a similar collaborative yield
+//! strategy had to be implemented manually
+
+use std::{
+    cell::RefCell,
+    task::{Context, Poll},
+};
+
+thread_local! {
+    static CURRENT: RefCell<u8> = RefCell::new(128);
+}
+
+/// Returns `Poll::Pending` if the current task has exceeded its budget and should yield.
+///
+/// User can insert this logic into your own implementation of future to actively yield the execution state
+#[inline]
+pub fn poll_proceed(cx: &mut Context<'_>) -> Poll<()> {
+    CURRENT.with(|cell| {
+        let mut budget = cell.borrow_mut();
+
+        *budget -= 1;
+        if *budget != 0 {
+            Poll::Ready(())
+        } else {
+            *budget = 128;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::{executor::block_on, future::poll_fn};
+    use std::thread;
+
+    fn get() -> u8 {
+        CURRENT.with(|cell| *cell.borrow())
+    }
+
+    #[test]
+    fn test_budget() {
+        assert_eq!(get(), 128);
+        block_on(poll_fn(|cx| poll_proceed(cx)));
+        assert_eq!(get(), 127);
+
+        thread::spawn(|| {
+            assert_eq!(get(), 128);
+            block_on(async {
+                for _ in 0..2 {
+                    poll_fn(|cx| poll_proceed(cx)).await
+                }
+            });
+            assert_eq!(get(), 126);
+        })
+        .join()
+        .unwrap();
+        assert_eq!(get(), 127);
+        block_on(async {
+            for _ in 0..127 {
+                poll_fn(|cx| poll_proceed(cx)).await
+            }
+        });
+        assert_eq!(get(), 127);
+    }
+}

--- a/tentacle/src/runtime/mod.rs
+++ b/tentacle/src/runtime/mod.rs
@@ -56,6 +56,9 @@ mod generic_split {
     }
 }
 
+mod budget;
+pub use budget::*;
+
 use futures::{ready, AsyncRead as FutureAsyncRead, AsyncWrite as FutureAsyncWrite};
 use std::{
     fmt, io,

--- a/tentacle/src/runtime/tokio_runtime.rs
+++ b/tentacle/src/runtime/tokio_runtime.rs
@@ -1,7 +1,7 @@
 pub use tokio::{
     net::{TcpListener, TcpStream},
     spawn,
-    task::{block_in_place, spawn_blocking, JoinHandle},
+    task::{block_in_place, spawn_blocking, yield_now, JoinHandle},
 };
 
 use crate::service::config::TcpSocketConfig;

--- a/tentacle/src/runtime/tokio_runtime.rs
+++ b/tentacle/src/runtime/tokio_runtime.rs
@@ -4,7 +4,7 @@ pub use tokio::{
     task::{block_in_place, spawn_blocking, yield_now, JoinHandle},
 };
 
-use crate::service::config::TcpSocketConfig;
+use crate::service::config::{TcpSocket, TcpSocketConfig};
 use socket2::{Domain, Protocol as SocketProtocol, Socket, Type};
 #[cfg(unix)]
 use std::os::unix::io::{FromRawFd, IntoRawFd};
@@ -75,7 +75,7 @@ pub(crate) fn listen(addr: SocketAddr, tcp_config: TcpSocketConfig) -> io::Resul
         // user can disable it on tcp_config
         #[cfg(not(windows))]
         socket.set_reuse_address(true)?;
-        let t = tcp_config(socket.into())?;
+        let t = tcp_config(TcpSocket { inner: socket })?;
         t.inner.set_nonblocking(true)?;
         // safety: fd convert by socket2
         unsafe {
@@ -108,7 +108,7 @@ pub(crate) async fn connect(
     let socket = Socket::new(domain, Type::STREAM, Some(SocketProtocol::TCP))?;
 
     let socket = {
-        let t = tcp_config(socket.into())?;
+        let t = tcp_config(TcpSocket { inner: socket })?;
         t.inner.set_nonblocking(true)?;
         // safety: fd convert by socket2
         unsafe {

--- a/tentacle/src/runtime/wasm_runtime.rs
+++ b/tentacle/src/runtime/wasm_runtime.rs
@@ -57,5 +57,6 @@ pub async fn yield_now() {
         yielded = true;
         cx.waker().wake_by_ref();
         Poll::Pending
-    }).await
+    })
+    .await
 }

--- a/tentacle/src/runtime/wasm_runtime.rs
+++ b/tentacle/src/runtime/wasm_runtime.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen_futures::spawn_local;
 
-use futures::channel::oneshot;
+use futures::{channel::oneshot, future::poll_fn};
 use std::{
     future::Future,
     io,
@@ -44,4 +44,18 @@ where
     });
 
     JoinHandle { recv: rx }
+}
+
+pub async fn yield_now() {
+    let mut yielded = false;
+
+    poll_fn(|cx| {
+        if yielded {
+            return Poll::Ready(());
+        }
+
+        yielded = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }).await
 }

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -1,4 +1,4 @@
-use futures::{channel::mpsc, prelude::*, stream::StreamExt};
+use futures::{channel::mpsc, future::poll_fn, prelude::*, stream::StreamExt};
 use log::{debug, error, trace};
 use nohash_hasher::IntMap;
 use std::{
@@ -1238,6 +1238,8 @@ where
                 self.wait_handle_poll().await;
                 break;
             }
+
+            poll_fn(|cx| crate::runtime::poll_proceed(cx)).await;
             #[cfg(not(target_arch = "wasm32"))]
             self.try_update_listens().await;
             tokio::select! {

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -121,13 +121,6 @@ pub struct TcpSocket {
     pub(crate) inner: socket2::Socket,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl From<socket2::Socket> for TcpSocket {
-    fn from(s: socket2::Socket) -> TcpSocket {
-        TcpSocket { inner: s }
-    }
-}
-
 #[cfg(unix)]
 impl AsRawFd for TcpSocket {
     fn as_raw_fd(&self) -> RawFd {

--- a/tentacle/src/service/future_task.rs
+++ b/tentacle/src/service/future_task.rs
@@ -98,6 +98,8 @@ impl Stream for FutureTaskManager {
             return Poll::Ready(None);
         }
 
+        futures::ready!(crate::runtime::poll_proceed(cx));
+
         let mut is_pending = match Pin::new(&mut self.task_receiver).as_mut().poll_next(cx) {
             Poll::Ready(Some(task)) => {
                 self.add_task(task);

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -763,6 +763,8 @@ impl Stream for Session {
 
         self.flush(cx);
 
+        futures::ready!(crate::runtime::poll_proceed(cx));
+
         let mut is_pending = self.recv_substreams(cx).is_pending();
 
         is_pending &= self.recv_service(cx).is_pending();

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -472,6 +472,8 @@ where
             self.event_sender.len()
         );
 
+        futures::ready!(crate::runtime::poll_proceed(cx));
+
         let mut is_pending = self.recv_frame(cx).is_pending();
 
         is_pending &= self.recv_event(cx).is_pending();
@@ -844,6 +846,8 @@ where
             self.event_sender.len()
         );
 
+        futures::ready!(crate::runtime::poll_proceed(cx));
+
         let is_pending = self.recv_event(cx).is_pending();
 
         if is_pending {
@@ -893,6 +897,7 @@ impl Stream for SubstreamReadPart {
     type Item = Result<bytes::Bytes, io::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        futures::ready!(crate::runtime::poll_proceed(cx));
         match self.substream.poll_next_unpin(cx) {
             Poll::Ready(Some(Ok(data))) => {
                 let data = match self.before_receive {

--- a/tentacle/tests/test_uninterrupter_poll.rs
+++ b/tentacle/tests/test_uninterrupter_poll.rs
@@ -1,0 +1,87 @@
+use futures::channel;
+use tentacle::{
+    async_trait,
+    builder::{MetaBuilder, ServiceBuilder},
+    bytes::Bytes,
+    context::{ProtocolContext, ProtocolContextMutRef},
+    multiaddr::Multiaddr,
+    service::{ProtocolHandle, ProtocolMeta, Service, TargetProtocol},
+    traits::{ServiceHandle, ServiceProtocol},
+    ProtocolId,
+};
+
+struct PHandle;
+
+#[async_trait]
+impl ServiceProtocol for PHandle {
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
+
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
+        if context.session.ty.is_inbound() {
+            let prefix = "x".repeat(10);
+            let _res = context.send_message(Bytes::from(prefix)).await;
+        }
+    }
+
+    async fn disconnected(&mut self, context: ProtocolContextMutRef<'_>) {
+        let _res = context.shutdown().await;
+    }
+
+    async fn received(&mut self, context: ProtocolContextMutRef<'_>, _data: Bytes) {
+        if context.session.ty.is_outbound() {
+            let _res = context.shutdown().await;
+        }
+    }
+    async fn poll(&mut self, _context: &mut ProtocolContext) -> Option<()> {
+        Some(())
+    }
+}
+
+fn create_meta(id: ProtocolId) -> ProtocolMeta {
+    MetaBuilder::new()
+        .id(id)
+        .service_handle(move || {
+            let handle = Box::new(PHandle);
+            ProtocolHandle::Callback(handle)
+        })
+        .build()
+}
+
+pub fn create<F>(meta: ProtocolMeta, shandle: F) -> Service<F>
+where
+    F: ServiceHandle + Unpin,
+{
+    ServiceBuilder::default()
+        .insert_protocol(meta)
+        .forever(true)
+        .build(shandle)
+}
+
+#[test]
+fn test_uninterrupter_poll() {
+    let mut service_0 = create(create_meta(1.into()), ());
+    let mut service_1 = create(create_meta(1.into()), ());
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
+    rt.spawn(async move {
+        let listen_addr = service_0
+            .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+            .await
+            .unwrap();
+        let _res = addr_sender.send(listen_addr);
+        service_0.run().await
+    });
+
+    rt.block_on(async move {
+        let listen_addr = addr_receiver.await.unwrap();
+        service_1
+            .dial(listen_addr, TargetProtocol::All)
+            .await
+            .unwrap();
+        service_1.run().await
+    });
+}


### PR DESCRIPTION
In the process of upgrading the ckb dependency, I encountered the problem that the unit test did not pass after the upgrade, and after spending about two days locating and fixing it, I produced this PR.

First of all, the problem arises when the upgrade process incorrectly implements a trait, which happens with ckb's ping protocol:
```rust
    /// Behave like `Stream::poll_next`, but nothing output
    /// if ready with Some, it will continue poll immediately
    /// if ready with None, it will don't try to call the function again
    #[inline]
    async fn poll(&mut self, _context: ProtocolContextMutRef<'_>) -> Option<()> {
        Some(())
    }
```
This implementation causes the future generated by this method to be called uninterruptedly, which is not a big problem when a runtime starts a network, but when multiple networks are created at the same time, all workers will be stuck in this future and other tasks will not be executed, which causes the unit tests of the [network module](https://github.com/nervosnetwork/ckb/blob/develop/network/src/protocols/tests/mod.rs) to fail extensively, but the integration tests pass entirely.

In rust's collaborative asynchronous model, the problem of user implementation errors is hard to cure, but as a framework, we have to make the implementation work as well as possible, so I introduced tokio's [budget model](https://tokio.rs/blog/2020-04-preemption), which takes the framework's controllable future and adds the logic of forced yield to make it work as well as possible even in exception states. Since we don't have a need to disable it, the implementation is simpler than tokio.

**The ckb network unit test passes 100% even in the bad implementation**(ping protocol impl with `Some(())`).

There are many ways to implement the budget.
1. inline it into the implementation of the specified Future, which causes each future to keep track of its own execution times
2. introduce budget as a CPU-like time slice, i.e. the current implementation, which is less intrusive and can be shared externally, which is how tokio is implemented, but it does not expose the calling interface for now(unstable with [consume_budget](https://docs.rs/tokio/latest/tokio/task/fn.consume_budget.html#), but it can't use on poll fn)


Another bug fixed in the implementation of poll fn, which does not call it if it returns none, as the documentation says

Remove the external exposure of socket2, so that external interaction is only possible via fd