### PR TITLE
chore: bump secio to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## secio 0.6.1
+
+### Features
+- Expose the PublicKey `from_raw_key` api
+
 ## yamux 0.3.8 secio 0.6.0 tentacle 0.5.0-alpha.1
 
 ### Features

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tentacle-secio"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 description = "Secio encryption protocol for p2p"
 authors = ["piaoliu <driftluo@foxmail.com>", "Nervos Core Dev <dev@nervos.org>"]

--- a/secio/src/handshake/handshake_struct.rs
+++ b/secio/src/handshake/handshake_struct.rs
@@ -134,6 +134,11 @@ impl PublicKey {
         self.key
     }
 
+    /// from raw pubkey
+    pub fn from_raw_key(pubkey: Vec<u8>) -> Self {
+        PublicKey { key: pubkey }
+    }
+
     /// Encode with molecule
     pub fn encode(self) -> Bytes {
         let secp256k1 = handshake_mol::Secp256k1::new_builder()

--- a/secio/src/handshake/procedure.rs
+++ b/secio/src/handshake/procedure.rs
@@ -156,7 +156,7 @@ where
 
     let data_to_verify = crate::sha256_compat::sha256(&data_to_verify);
 
-    if !<K as KeyProvider>::verify_ecdsa(
+    if !ephemeral_context.config.key_provider.verify_ecdsa(
         ephemeral_context.state.remote.public_key.inner_ref(),
         data_to_verify,
         &remote_exchanges.signature,

--- a/secio/src/lib.rs
+++ b/secio/src/lib.rs
@@ -135,7 +135,7 @@ pub trait KeyProvider: std::clone::Clone + Send + Sync + 'static {
     fn pubkey(&self) -> Vec<u8>;
 
     /// Checks that `sig` is a valid ECDSA signature for `msg` using the pubkey.
-    fn verify_ecdsa<P, T, F>(pubkey: P, message: T, signature: F) -> bool
+    fn verify_ecdsa<P, T, F>(&self, pubkey: P, message: T, signature: F) -> bool
     where
         P: AsRef<[u8]>,
         T: AsRef<[u8]>,
@@ -168,7 +168,7 @@ impl KeyProvider for SecioKeyPair {
         }
     }
 
-    fn verify_ecdsa<P, T, F>(pubkey: P, message: T, signature: F) -> bool
+    fn verify_ecdsa<P, T, F>(&self, pubkey: P, message: T, signature: F) -> bool
     where
         P: AsRef<[u8]>,
         T: AsRef<[u8]>,
@@ -205,7 +205,7 @@ impl KeyProvider for NoopKeyProvider {
         Vec::new()
     }
 
-    fn verify_ecdsa<P, T, F>(_pubkey: P, _message: T, _signature: F) -> bool
+    fn verify_ecdsa<P, T, F>(&self, _pubkey: P, _message: T, _signature: F) -> bool
     where
         P: AsRef<[u8]>,
         T: AsRef<[u8]>,


### PR DESCRIPTION
https://github.com/nervosnetwork/tentacle/pull/366/files#diff-b60df668d0b0edb322e9b7319ada7c4b1b54191095cb3209d741b1e66bc10ad4L143

1. Expose the PublicKey `from_raw_key` api
2. I will yank 0.6.0, because `KeyProvider` has changed

why change `KeyProvider::verify_ecdsa` with self-bound?

If the user wants to combine the two Keys into one enum, user can only write the following implementation, but such an implementation has security issues
```rust
#[derive(Clone)]
enum KeyP<K: KeyProvider> {
    Custom(K),
    Default(SecioKeyPair),
}
#[async_trait]
impl<K> KeyProvider for KeyP<K>
where
    K: KeyProvider,
{
    type Error = SecioError;

    async fn sign_ecdsa_async<T: AsRef<[u8]> + Send>(
        &self,
        message: T,
    ) -> Result<Vec<u8>, Self::Error> {
        match self {
            KeyP::Custom(k) => k.sign_ecdsa_async(message).await.map_err(Into::into),
            KeyP::Default(k) => k.sign_ecdsa_async(message).await,
        }
    }

    /// Constructs a signature for `msg` using the secret key `sk`
    fn sign_ecdsa<T: AsRef<[u8]>>(&self, message: T) -> Result<Vec<u8>, Self::Error> {
        match self {
            KeyP::Custom(k) => k.sign_ecdsa(message).map_err(Into::into),
            KeyP::Default(k) => k.sign_ecdsa(message),
        }
    }

    /// Creates a new public key from the [`KeyProvider`].
    fn pubkey(&self) -> Vec<u8> {
        match self {
            KeyP::Custom(k) => k.pubkey(),
            KeyP::Default(k) => k.pubkey(),
        }
    }

    /// Checks that `sig` is a valid ECDSA signature for `msg` using the
    /// pubkey.
    fn verify_ecdsa<P, T, F>(pubkey: P, message: T, signature: F) -> bool
    where
        P: AsRef<[u8]>,
        T: AsRef<[u8]>,
        F: AsRef<[u8]>,
    {
        <K as KeyProvider>::verify_ecdsa(pubkey.as_ref(), message.as_ref(), signature.as_ref())
            || SecioKeyPair::verify_ecdsa(pubkey, message, signature)
    }
}
```
After binding self, it can be implemented according to the implementation type