### PR TITLE
feat: enable tcp base protocol listen on same port

### DIFF
--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -31,6 +31,7 @@ nohash-hasher = "0.2"
 
 parking_lot = { version = "0.12", optional = true }
 tokio-tungstenite = { version = "0.24", optional = true }
+httparse = { version = "1.9", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 async-std = { version = "1", features = ["unstable"], optional = true }
 async-io = { version = "1", optional = true }
@@ -76,7 +77,7 @@ nix = { version = "0.29", default-features = false, features = ["signal"] }
 
 [features]
 default = ["tokio-runtime", "tokio-timer"]
-ws = ["tokio-tungstenite"]
+ws = ["tokio-tungstenite", "httparse"]
 tls = ["tokio-rustls"]
 upnp = ["igd"]
 secio-async-trait = ["secio/async-trait"]

--- a/tentacle/examples/simple.rs
+++ b/tentacle/examples/simple.rs
@@ -217,7 +217,7 @@ fn server() {
             .unwrap();
         #[cfg(feature = "ws")]
         service
-            .listen("/ip4/127.0.0.1/tcp/1338/ws".parse().unwrap())
+            .listen("/ip4/127.0.0.1/tcp/1337/ws".parse().unwrap())
             .await
             .unwrap();
         service.run().await

--- a/tentacle/src/buffer.rs
+++ b/tentacle/src/buffer.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 /// If the buffer unused capacity is greater than u8 max, shrink it
-const BUF_SHRINK_THRESHOLD: usize = u8::max_value() as usize;
+const BUF_SHRINK_THRESHOLD: usize = u8::MAX as usize;
 
 pub enum SendResult {
     Ok,

--- a/tentacle/src/channel/mod.rs
+++ b/tentacle/src/channel/mod.rs
@@ -22,7 +22,7 @@ pub use sink_impl::QuickSinkExt;
 use std::fmt;
 
 // The `is_open` flag is stored in the left-most bit of `Inner::state`
-const OPEN_MASK: usize = usize::max_value() - (usize::max_value() >> 1);
+const OPEN_MASK: usize = usize::MAX - (usize::MAX >> 1);
 
 // When a new channel is created, it is created in the open state with no
 // pending messages.

--- a/tentacle/src/lock/mod.rs
+++ b/tentacle/src/lock/mod.rs
@@ -1,10 +1,9 @@
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 #[cfg(feature = "parking_lot")]
 pub use parking_lot::{const_fair_mutex, const_mutex, const_rwlock, FairMutex, Mutex, RwLock};
 #[cfg(not(feature = "parking_lot"))]
 pub mod native;
 
-#[allow(unused_imports)]
 #[cfg(not(feature = "parking_lot"))]
 pub use native::{Mutex, RwLock};

--- a/tentacle/src/runtime/async_runtime.rs
+++ b/tentacle/src/runtime/async_runtime.rs
@@ -101,6 +101,10 @@ mod os {
         pub fn peer_addr(&self) -> io::Result<SocketAddr> {
             self.0.get_ref().peer_addr()
         }
+
+        pub async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+            self.0.get_ref().peek(buf).await
+        }
     }
 
     impl AsyncRead for TcpStream {

--- a/tentacle/src/runtime/budget.rs
+++ b/tentacle/src/runtime/budget.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 thread_local! {
-    static CURRENT: RefCell<u8> = RefCell::new(128);
+    static CURRENT: RefCell<u8> = const { RefCell::new(128) };
 }
 
 /// Returns `Poll::Pending` if the current task has exceeded its budget and should yield.

--- a/tentacle/src/runtime/tokio_runtime.rs
+++ b/tentacle/src/runtime/tokio_runtime.rs
@@ -59,7 +59,7 @@ mod time {
         }
 
         fn size_hint(&self) -> (usize, Option<usize>) {
-            (std::usize::MAX, None)
+            (usize::MAX, None)
         }
     }
 

--- a/tentacle/src/service/future_task.rs
+++ b/tentacle/src/service/future_task.rs
@@ -188,7 +188,7 @@ mod test {
         let mut manager = FutureTaskManager::new(receiver, shutdown);
         let finished_tasks = Arc::new(AtomicUsize::new(0));
         let finished_tasks_inner = Arc::clone(&finished_tasks);
-        let signals_len = Arc::new(AtomicUsize::new(usize::max_value()));
+        let signals_len = Arc::new(AtomicUsize::new(usize::MAX));
         let signals_len_inner = Arc::clone(&signals_len);
 
         let mut send_task = sender.clone();

--- a/tentacle/src/transports/browser.rs
+++ b/tentacle/src/transports/browser.rs
@@ -36,7 +36,9 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::{
     error::TransportErrorKind,
     multiaddr::{Multiaddr, Protocol},
-    transports::{find_type, Result, Transport, TransportFuture, TransportType},
+    transports::{
+        find_type, Result, TransportDial, TransportFuture, TransportListen, TransportType,
+    },
     utils::multiaddr_to_socketaddr,
 };
 use futures::FutureExt;
@@ -113,13 +115,16 @@ impl BrowserTransport {
 pub type BrowserDialFuture =
     TransportFuture<Pin<Box<dyn Future<Output = Result<(Multiaddr, BrowserStream)>> + Send>>>;
 
-impl Transport for BrowserTransport {
+impl TransportListen for BrowserTransport {
     type ListenFuture = ();
-    type DialFuture = BrowserDialFuture;
 
     fn listen(self, address: Multiaddr) -> Result<Self::ListenFuture> {
         Err(TransportErrorKind::NotSupported(address))
     }
+}
+
+impl TransportDial for BrowserTransport {
+    type DialFuture = BrowserDialFuture;
 
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
         if !matches!(find_type(&address), TransportType::Ws) {

--- a/tentacle/src/transports/memory.rs
+++ b/tentacle/src/transports/memory.rs
@@ -2,7 +2,7 @@ use crate::{
     error::TransportErrorKind,
     lock::Mutex,
     multiaddr::{Multiaddr, Protocol},
-    transports::{Result, Transport, TransportFuture},
+    transports::{Result, TransportDial, TransportFuture, TransportListen},
 };
 
 use bytes::Bytes;
@@ -120,15 +120,16 @@ pub type MemoryListenFuture =
 pub type MemoryDialFuture =
     TransportFuture<Pin<Box<dyn Future<Output = Result<(Multiaddr, MemorySocket)>> + Send>>>;
 
-impl Transport for MemoryTransport {
+impl TransportListen for MemoryTransport {
     type ListenFuture = MemoryListenFuture;
-    type DialFuture = MemoryDialFuture;
 
     fn listen(self, address: Multiaddr) -> Result<Self::ListenFuture> {
         let task = bind(address);
         Ok(TransportFuture::new(Box::pin(task)))
     }
-
+}
+impl TransportDial for MemoryTransport {
+    type DialFuture = MemoryDialFuture;
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
         let task = connect(address);
         Ok(TransportFuture::new(Box::pin(task)))

--- a/tentacle/src/transports/tcp_base_listen.rs
+++ b/tentacle/src/transports/tcp_base_listen.rs
@@ -1,0 +1,529 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    future::Future,
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    channel::mpsc::{self, Receiver, Sender},
+    SinkExt, Stream,
+};
+use log::debug;
+
+#[cfg(any(feature = "ws", feature = "tls"))]
+use crate::multiaddr::Protocol;
+#[cfg(feature = "ws")]
+use {crate::transports::ws::WsStream, tokio_tungstenite::accept_async};
+#[cfg(feature = "tls")]
+use {
+    crate::{service::TlsConfig, transports::parse_tls_domain_name},
+    std::borrow::Cow,
+    tokio_rustls::{
+        rustls::{server::ResolvesServerCertUsingSni, ServerConfig},
+        TlsAcceptor,
+    },
+};
+
+use crate::{
+    multiaddr::Multiaddr,
+    runtime::{TcpListener, TcpStream},
+    service::config::TcpSocketConfig,
+    transports::{tcp_listen, MultiStream, Result, TcpListenMode, TransportErrorKind},
+    utils::{multiaddr_to_socketaddr, socketaddr_to_multiaddr},
+};
+
+pub enum TcpBaseListenerEnum {
+    Upgrade,
+    New(TcpBaseListener),
+}
+
+/// Tcp listen bind
+pub async fn bind(
+    address: impl Future<Output = Result<Multiaddr>>,
+    tcp_config: TcpSocketConfig,
+    listen_mode: TcpListenMode,
+    #[cfg(feature = "tls")] config: TlsConfig,
+    global: Arc<crate::lock::Mutex<HashMap<SocketAddr, UpgradeMode>>>,
+    timeout: Duration,
+) -> Result<(Multiaddr, TcpBaseListenerEnum)> {
+    let addr = address.await?;
+    let upgrade_mode: UpgradeMode = listen_mode.into();
+    match multiaddr_to_socketaddr(&addr) {
+        Some(socket_address) => {
+            let (local_addr, tcp) = if socket_address.port() == 0 {
+                // this branch must be unique address
+                let (local_addr, tcp) = tcp_listen(socket_address, tcp_config).await?;
+                global
+                    .clone()
+                    .lock()
+                    .insert(local_addr, upgrade_mode.clone());
+                (local_addr, tcp)
+            } else {
+                // Global register global listener upgrade mode
+                match global.clone().lock().entry(socket_address) {
+                    Entry::Occupied(v) => {
+                        #[allow(unused_mut)]
+                        let mut tcp_base_addr: Multiaddr = socketaddr_to_multiaddr(socket_address);
+                        let listen_addr = match listen_mode {
+                            TcpListenMode::Tcp => tcp_base_addr,
+                            #[cfg(feature = "ws")]
+                            TcpListenMode::Ws => {
+                                tcp_base_addr.push(Protocol::Ws);
+                                tcp_base_addr
+                            }
+                            #[cfg(feature = "tls")]
+                            TcpListenMode::Tls => {
+                                match parse_tls_domain_name(&addr) {
+                                    None => return Err(TransportErrorKind::NotSupported(addr)),
+                                    Some(d) => {
+                                        tcp_base_addr.push(Protocol::Tls(Cow::Owned(d)));
+                                    }
+                                }
+                                tcp_base_addr
+                            }
+                        };
+                        v.get().combine(listen_mode.into());
+                        return Ok((listen_addr, TcpBaseListenerEnum::Upgrade));
+                    }
+                    Entry::Vacant(v) => {
+                        v.insert(upgrade_mode.clone());
+                    }
+                }
+                tcp_listen(socket_address, tcp_config).await?
+            };
+            #[allow(unused_mut)]
+            let mut tcp_base_addr: Multiaddr = socketaddr_to_multiaddr(local_addr);
+            let listen_addr = match listen_mode {
+                TcpListenMode::Tcp => tcp_base_addr,
+                #[cfg(feature = "ws")]
+                TcpListenMode::Ws => {
+                    tcp_base_addr.push(Protocol::Ws);
+                    tcp_base_addr
+                }
+                #[cfg(feature = "tls")]
+                TcpListenMode::Tls => {
+                    match parse_tls_domain_name(&addr) {
+                        None => return Err(TransportErrorKind::NotSupported(addr)),
+                        Some(d) => {
+                            tcp_base_addr.push(Protocol::Tls(Cow::Owned(d)));
+                        }
+                    }
+                    tcp_base_addr
+                }
+            };
+            #[cfg(feature = "tls")]
+            let tls_server_config = config.tls_server_config.unwrap_or(
+                // if enable tls but not set tls config, it will use a empty server config
+                Arc::new(
+                    ServerConfig::builder()
+                        .with_no_client_auth()
+                        .with_cert_resolver(Arc::new(ResolvesServerCertUsingSni::new())),
+                ),
+            );
+
+            Ok((
+                listen_addr,
+                TcpBaseListenerEnum::New({
+                    let tcp_listen =
+                        TcpBaseListener::new(timeout, tcp, local_addr, upgrade_mode, global);
+                    #[cfg(feature = "tls")]
+                    let tcp_listen = tcp_listen.tls_config(tls_server_config);
+                    tcp_listen
+                }),
+            ))
+        }
+        None => Err(TransportErrorKind::NotSupported(addr)),
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct UpgradeMode {
+    inner: Arc<AtomicU8>,
+}
+
+impl UpgradeMode {
+    pub fn combine(&self, other: UpgradeModeEnum) {
+        let other = other as u8;
+        self.inner.fetch_or(other, Ordering::AcqRel);
+    }
+
+    pub fn to_enum(&self) -> UpgradeModeEnum {
+        self.inner.load(Ordering::Acquire).into()
+    }
+}
+
+impl From<UpgradeModeEnum> for UpgradeMode {
+    fn from(value: UpgradeModeEnum) -> Self {
+        Self {
+            inner: Arc::new(AtomicU8::from(value as u8)),
+        }
+    }
+}
+
+impl From<TcpListenMode> for UpgradeMode {
+    fn from(value: TcpListenMode) -> Self {
+        match value {
+            TcpListenMode::Tcp => UpgradeModeEnum::OnlyTcp.into(),
+            #[cfg(feature = "tls")]
+            TcpListenMode::Tls => UpgradeModeEnum::OnlyTls.into(),
+            #[cfg(feature = "ws")]
+            TcpListenMode::Ws => UpgradeModeEnum::OnlyWs.into(),
+        }
+    }
+}
+
+impl From<TcpListenMode> for UpgradeModeEnum {
+    fn from(value: TcpListenMode) -> Self {
+        match value {
+            TcpListenMode::Tcp => UpgradeModeEnum::OnlyTcp,
+            #[cfg(feature = "tls")]
+            TcpListenMode::Tls => UpgradeModeEnum::OnlyTls,
+            #[cfg(feature = "ws")]
+            TcpListenMode::Ws => UpgradeModeEnum::OnlyWs,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum UpgradeModeEnum {
+    OnlyTcp = 0b1,
+    #[cfg(feature = "ws")]
+    OnlyWs = 0b10,
+    #[cfg(feature = "tls")]
+    OnlyTls = 0b100,
+    #[cfg(feature = "ws")]
+    TcpAndWs = 0b11,
+    #[cfg(feature = "tls")]
+    TcpAndTls = 0b101,
+    #[cfg(all(feature = "ws", feature = "tls"))]
+    All = 0b111,
+}
+
+impl From<u8> for UpgradeModeEnum {
+    fn from(value: u8) -> Self {
+        match value {
+            0b1 => UpgradeModeEnum::OnlyTcp,
+            #[cfg(feature = "ws")]
+            0b10 => UpgradeModeEnum::OnlyWs,
+            #[cfg(feature = "ws")]
+            0b11 => UpgradeModeEnum::TcpAndWs,
+            #[cfg(feature = "tls")]
+            0b100 => UpgradeModeEnum::OnlyTls,
+            #[cfg(feature = "tls")]
+            0b101 => UpgradeModeEnum::TcpAndTls,
+            #[cfg(all(feature = "ws", feature = "tls"))]
+            0b111 => UpgradeModeEnum::All,
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub struct TcpBaseListener {
+    inner: TcpListener,
+    upgrade_mode: UpgradeMode,
+    timeout: Duration,
+    local_addr: SocketAddr,
+    sender: Sender<(Multiaddr, MultiStream)>,
+    pending_stream: Receiver<(Multiaddr, MultiStream)>,
+    global: Arc<crate::lock::Mutex<HashMap<SocketAddr, UpgradeMode>>>,
+    #[cfg(feature = "tls")]
+    tls_config: Arc<ServerConfig>,
+}
+
+impl Drop for TcpBaseListener {
+    fn drop(&mut self) {
+        self.global.lock().remove(&self.local_addr);
+    }
+}
+
+impl TcpBaseListener {
+    fn new(
+        timeout: Duration,
+        inner: TcpListener,
+        local_addr: SocketAddr,
+        upgrade_mode: UpgradeMode,
+        global: Arc<crate::lock::Mutex<HashMap<SocketAddr, UpgradeMode>>>,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(128);
+
+        Self {
+            inner,
+            timeout,
+            upgrade_mode,
+            local_addr,
+            global,
+            sender: tx,
+            pending_stream: rx,
+            #[cfg(feature = "tls")]
+            tls_config: Arc::new(
+                ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_cert_resolver(Arc::new(ResolvesServerCertUsingSni::new())),
+            ),
+        }
+    }
+
+    #[cfg(feature = "tls")]
+    fn tls_config(mut self, tls_config: Arc<ServerConfig>) -> Self {
+        self.tls_config = tls_config;
+        self
+    }
+
+    fn poll_pending(&mut self, cx: &mut Context) -> Poll<(Multiaddr, MultiStream)> {
+        match Pin::new(&mut self.pending_stream).as_mut().poll_next(cx) {
+            Poll::Ready(Some(res)) => Poll::Ready(res),
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_listen(&mut self, cx: &mut Context) -> Poll<std::result::Result<(), io::Error>> {
+        match self.inner.poll_accept(cx)? {
+            Poll::Ready((stream, _)) => {
+                // Why can't get the peer address of the connected stream ?
+                // Error will be "Transport endpoint is not connected",
+                // so why incoming will appear unconnected stream ?
+                match stream.peer_addr() {
+                    Ok(remote_address) => {
+                        let timeout = self.timeout;
+                        let sender = self.sender.clone();
+                        let upgrade_mode = self.upgrade_mode.to_enum();
+                        #[cfg(feature = "tls")]
+                        let acceptor = TlsAcceptor::from(Arc::clone(&self.tls_config));
+                        crate::runtime::spawn(protocol_select(
+                            stream,
+                            timeout,
+                            upgrade_mode,
+                            sender,
+                            remote_address,
+                            #[cfg(feature = "tls")]
+                            acceptor,
+                        ));
+                    }
+                    Err(err) => {
+                        debug!("stream get peer address error: {:?}", err);
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Stream for TcpBaseListener {
+    type Item = std::result::Result<(Multiaddr, MultiStream), io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(res) = self.poll_pending(cx) {
+            return Poll::Ready(Some(Ok(res)));
+        }
+
+        loop {
+            let is_pending = self.poll_listen(cx)?.is_pending();
+            match self.poll_pending(cx) {
+                Poll::Ready(res) => return Poll::Ready(Some(Ok(res))),
+                Poll::Pending => {
+                    if is_pending {
+                        break;
+                    }
+                }
+            }
+        }
+        Poll::Pending
+    }
+}
+
+async fn protocol_select(
+    stream: TcpStream,
+    timeout: Duration,
+    #[allow(unused_mut)] mut upgrade_mode: UpgradeModeEnum,
+    mut sender: Sender<(Multiaddr, MultiStream)>,
+    remote_address: SocketAddr,
+    #[cfg(feature = "tls")] acceptor: TlsAcceptor,
+) {
+    let mut peek_buf = [0u8; 16];
+    let now = std::time::Instant::now();
+    loop {
+        match stream.peek(&mut peek_buf).await {
+            Ok(n) => {
+                if n != 16 {
+                    if now.elapsed() > timeout {
+                        debug!(
+                            "In the timeout range, stream can't read more than 16 byte data, 
+                        We need to give up this suspected offensive stream"
+                        );
+                        return;
+                    } else {
+                        continue;
+                    }
+                }
+                break;
+            }
+            Err(e) => {
+                debug!("stream encountered err: {}, close unexpectedly", e);
+                return;
+            }
+        }
+    }
+
+    loop {
+        match upgrade_mode {
+            UpgradeModeEnum::OnlyTcp => {
+                if sender
+                    .send((
+                        socketaddr_to_multiaddr(remote_address),
+                        MultiStream::Tcp(stream),
+                    ))
+                    .await
+                    .is_err()
+                {
+                    debug!("receiver closed unexpectedly")
+                }
+                return;
+            }
+            #[cfg(feature = "ws")]
+            UpgradeModeEnum::OnlyWs => {
+                match crate::runtime::timeout(timeout, accept_async(stream)).await {
+                    Err(_) => debug!("accept websocket stream timeout"),
+                    Ok(res) => match res {
+                        Ok(stream) => {
+                            let mut addr = socketaddr_to_multiaddr(remote_address);
+                            addr.push(Protocol::Ws);
+                            if sender
+                                .send((addr, MultiStream::Ws(Box::new(WsStream::new(stream)))))
+                                .await
+                                .is_err()
+                            {
+                                debug!("receiver closed unexpectedly")
+                            }
+                        }
+                        Err(err) => {
+                            debug!("accept websocket stream err: {:?}", err);
+                        }
+                    },
+                }
+                return;
+            }
+            #[cfg(feature = "tls")]
+            UpgradeModeEnum::OnlyTls => {
+                match crate::runtime::timeout(timeout, acceptor.accept(stream)).await {
+                    Err(_) => debug!("accept tls server stream timeout"),
+                    Ok(res) => match res {
+                        Ok(stream) => {
+                            let mut addr = socketaddr_to_multiaddr(remote_address);
+                            addr.push(Protocol::Tls(Cow::Borrowed("")));
+                            if sender
+                                .send((addr, MultiStream::Tls(Box::new(stream))))
+                                .await
+                                .is_err()
+                            {
+                                debug!("receiver closed unexpectedly")
+                            }
+                        }
+                        Err(err) => {
+                            debug!("accept tls server stream err: {:?}", err);
+                        }
+                    },
+                }
+                return;
+            }
+            #[cfg(feature = "tls")]
+            UpgradeModeEnum::TcpAndTls => {
+                // The first sixteen bytes of secio's Propose message's mode is fixed
+                // it's bytes like follow:
+                //
+                // | 4 byte | 4 byte | 4 byte | 4 byte | 4 byte |...
+                // |--|--|--|--|--|
+                // | LengthDelimitedCodec header| molecule propose header | rand start | rand end/pubkey start | pubkey end/exchange start |...
+                //
+                // LengthDelimitedCodec header is big-end total len
+                // molecule propose header is little-end total len
+                // rand start offset is 24 = (5(feild count) + 1(total len))* 4
+                let length_delimited_header =
+                    u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&peek_buf[..4]).unwrap());
+                let molecule_header =
+                    u32::from_le_bytes(TryInto::<[u8; 4]>::try_into(&peek_buf[4..8]).unwrap());
+                let rand_start =
+                    u32::from_le_bytes(TryInto::<[u8; 4]>::try_into(&peek_buf[8..12]).unwrap());
+                let rand_end =
+                    u32::from_le_bytes(TryInto::<[u8; 4]>::try_into(&peek_buf[12..16]).unwrap());
+
+                // The first twelve bytes of yamux's message's mode is fixed
+                // it's bytes like follow:
+                // | byte | byte | 2 byte | 4 byte | 4 byte | ...
+                // |--|--|--|--|--|
+                // | version | type | flags(big-end) | steam_id(big-end) | header_len(big-end) |...
+                //
+                // yamux version is fixed = 0x0
+                // open window message type = 0x1, ping message type = 0x2
+                // flags is Syn = 0x1
+                // open window message stream id = 0x1(client standard implementation, but does not check, but can't be zero), ping message steam id = 0x0
+                // header_len is not a fixed value.
+                // It may be the ping_id or the window length value expressed in windowupdate.
+                let yamux_version = peek_buf[0];
+                let yamux_ty = peek_buf[1];
+                let yamux_flags =
+                    u16::from_be_bytes(TryInto::<[u8; 2]>::try_into(&peek_buf[2..4]).unwrap());
+                let yamux_stream_id =
+                    u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&peek_buf[4..8]).unwrap());
+
+                if (length_delimited_header == molecule_header
+                    && rand_start == 24
+                    && rand_start < rand_end
+                    && rand_end < molecule_header)
+                    || (yamux_version == 0
+                        && ((yamux_ty == 0x1 && yamux_stream_id != 0)
+                            || (yamux_ty == 0x2 && yamux_stream_id == 0))
+                        && yamux_flags == 0x1)
+                {
+                    upgrade_mode = UpgradeModeEnum::OnlyTcp;
+                    continue;
+                } else {
+                    upgrade_mode = UpgradeModeEnum::OnlyTls;
+                    continue;
+                }
+            }
+            #[cfg(feature = "ws")]
+            UpgradeModeEnum::TcpAndWs => {
+                let mut headers = [httparse::EMPTY_HEADER; 16];
+                let mut req = httparse::Request::new(&mut headers);
+
+                match req.parse(&peek_buf) {
+                    Ok(_) => {
+                        upgrade_mode = UpgradeModeEnum::OnlyWs;
+                        continue;
+                    }
+                    Err(_) => {
+                        upgrade_mode = UpgradeModeEnum::OnlyTcp;
+                        continue;
+                    }
+                }
+            }
+            #[cfg(all(feature = "ws", feature = "tls"))]
+            UpgradeModeEnum::All => {
+                let mut headers = [httparse::EMPTY_HEADER; 16];
+                let mut req = httparse::Request::new(&mut headers);
+
+                match req.parse(&peek_buf) {
+                    Ok(_) => {
+                        upgrade_mode = UpgradeModeEnum::OnlyWs;
+                        continue;
+                    }
+                    Err(_) => {
+                        upgrade_mode = UpgradeModeEnum::TcpAndTls;
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tentacle/src/transports/tls.rs
+++ b/tentacle/src/transports/tls.rs
@@ -1,57 +1,21 @@
 use super::Result;
-use futures::{future::ok, SinkExt, Stream, TryFutureExt};
-use log::{debug, warn};
-use std::{
-    borrow::Cow,
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+use futures::{future::ok, TryFutureExt};
+use std::{future::Future, pin::Pin, time::Duration};
 
-use crate::runtime::TcpListener;
 use crate::service::TlsConfig;
 use crate::{
     error::TransportErrorKind,
-    multiaddr::{Multiaddr, Protocol},
+    multiaddr::Multiaddr,
     service::config::TcpSocketConfig,
     session::AsyncRw,
-    transports::{tcp_dial, tcp_listen, Transport, TransportFuture},
-    utils::{dns::DnsResolver, multiaddr_to_socketaddr, socketaddr_to_multiaddr},
+    transports::{parse_tls_domain_name, tcp_dial, TransportDial, TransportFuture},
+    utils::{dns::DnsResolver, multiaddr_to_socketaddr},
 };
-use futures::channel::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
-use tokio::io;
-use tokio_rustls::rustls::{pki_types::ServerName, ServerConfig};
-use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::TlsConnector;
 
 pub type TlsStream = Box<dyn AsyncRw + Send + Unpin + 'static>;
-
-/// Tls listen bind
-async fn bind(
-    address: impl Future<Output = Result<Multiaddr>>,
-    timeout: Duration,
-    config: TlsConfig,
-    domain_name: String,
-    tcp_config: TcpSocketConfig,
-) -> Result<(Multiaddr, TlsListener)> {
-    let addr = address.await?;
-    match multiaddr_to_socketaddr(&addr) {
-        Some(socket_address) => {
-            let (local_addr, tcp) = tcp_listen(socket_address, tcp_config).await?;
-            let tls_server_config = config.tls_server_config.ok_or_else(|| {
-                TransportErrorKind::TlsError("server config not found".to_string())
-            })?;
-            let mut listen_addr = socketaddr_to_multiaddr(local_addr);
-            listen_addr.push(Protocol::Tls(Cow::Owned(domain_name)));
-            Ok((
-                listen_addr,
-                TlsListener::new(timeout, tcp, tls_server_config),
-            ))
-        }
-        None => Err(TransportErrorKind::NotSupported(addr)),
-    }
-}
 
 /// Tls connect
 async fn connect(
@@ -88,105 +52,6 @@ async fn connect(
     }
 }
 
-pub struct TlsListener {
-    inner: TcpListener,
-    timeout: Duration,
-    sender: Sender<(Multiaddr, TlsStream)>,
-    pending_stream: Receiver<(Multiaddr, TlsStream)>,
-    tls_config: Arc<ServerConfig>,
-}
-
-impl TlsListener {
-    fn new(timeout: Duration, listen: TcpListener, tls_config: Arc<ServerConfig>) -> Self {
-        let (sender, rx) = channel(24);
-        TlsListener {
-            inner: listen,
-            timeout,
-            sender,
-            pending_stream: rx,
-            tls_config,
-        }
-    }
-
-    fn poll_pending(&mut self, cx: &mut Context) -> Poll<(Multiaddr, TlsStream)> {
-        match Pin::new(&mut self.pending_stream).as_mut().poll_next(cx) {
-            Poll::Ready(Some(res)) => Poll::Ready(res),
-            Poll::Ready(None) | Poll::Pending => Poll::Pending,
-        }
-    }
-
-    fn poll_listen(&mut self, cx: &mut Context) -> Poll<std::result::Result<(), io::Error>> {
-        match self.inner.poll_accept(cx)? {
-            Poll::Ready((stream, _)) => {
-                match stream.peer_addr() {
-                    Ok(remote_address) => {
-                        let timeout = self.timeout;
-                        let mut sender = self.sender.clone();
-                        let acceptor = TlsAcceptor::from(Arc::clone(&self.tls_config));
-                        crate::runtime::spawn(async move {
-                            match crate::runtime::timeout(timeout, acceptor.accept(stream)).await {
-                                Err(_) => warn!("accept tls server stream timeout"),
-                                Ok(res) => match res {
-                                    Ok(stream) => {
-                                        let mut addr = socketaddr_to_multiaddr(remote_address);
-                                        addr.push(Protocol::Tls(Cow::Borrowed("")));
-                                        if sender.send((addr, Box::new(stream))).await.is_err() {
-                                            debug!("receiver closed unexpectedly")
-                                        }
-                                    }
-                                    Err(err) => {
-                                        warn!("accept tls server stream err: {:?}", err);
-                                    }
-                                },
-                            }
-                        });
-                    }
-                    Err(err) => {
-                        debug!("stream get peer address error: {:?}", err);
-                    }
-                }
-                Poll::Ready(Ok(()))
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl Stream for TlsListener {
-    type Item = std::result::Result<(Multiaddr, TlsStream), io::Error>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if let Poll::Ready(res) = self.poll_pending(cx) {
-            return Poll::Ready(Some(Ok(res)));
-        }
-
-        loop {
-            let is_pending = self.poll_listen(cx)?.is_pending();
-            match self.poll_pending(cx) {
-                Poll::Ready(res) => return Poll::Ready(Some(Ok(res))),
-                Poll::Pending => {
-                    if is_pending {
-                        break;
-                    }
-                }
-            }
-        }
-        Poll::Pending
-    }
-}
-
-fn parse_tls_domain_name(addr: &Multiaddr) -> Option<String> {
-    let mut iter = addr.iter();
-
-    iter.find_map(|proto| {
-        if let Protocol::Tls(s) = proto {
-            Some(s.to_string())
-        } else {
-            None
-        }
-    })
-}
-
 /// Tcp transport
 pub struct TlsTransport {
     timeout: Duration,
@@ -204,45 +69,11 @@ impl TlsTransport {
     }
 }
 
-pub type TlsListenFuture =
-    TransportFuture<Pin<Box<dyn Future<Output = Result<(Multiaddr, TlsListener)>> + Send>>>;
 pub type TlsDialFuture =
     TransportFuture<Pin<Box<dyn Future<Output = Result<(Multiaddr, TlsStream)>> + Send>>>;
 
-impl Transport for TlsTransport {
-    type ListenFuture = TlsListenFuture;
+impl TransportDial for TlsTransport {
     type DialFuture = TlsDialFuture;
-
-    fn listen(self, address: Multiaddr) -> Result<Self::ListenFuture> {
-        if let Some(domain_name) = parse_tls_domain_name(&address) {
-            match DnsResolver::new(address.clone()) {
-                Some(dns) => {
-                    let task = bind(
-                        dns.map_err(|(multiaddr, io_error)| {
-                            TransportErrorKind::DnsResolverError(multiaddr, io_error)
-                        }),
-                        self.timeout,
-                        self.config,
-                        domain_name,
-                        self.tcp_config,
-                    );
-                    Ok(TransportFuture::new(Box::pin(task)))
-                }
-                None => {
-                    let task = bind(
-                        ok(address),
-                        self.timeout,
-                        self.config,
-                        domain_name,
-                        self.tcp_config,
-                    );
-                    Ok(TransportFuture::new(Box::pin(task)))
-                }
-            }
-        } else {
-            Err(TransportErrorKind::NotSupported(address))
-        }
-    }
 
     fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
         if let Some(domain_name) = parse_tls_domain_name(&address) {

--- a/tentacle/src/utils.rs
+++ b/tentacle/src/utils.rs
@@ -114,6 +114,41 @@ pub fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
     })
 }
 
+/// Transport type on tentacle
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum TransportType {
+    /// Websocket
+    Ws,
+    /// Websocket with tls
+    Wss,
+    /// Tcp
+    Tcp,
+    /// Tcp with tls
+    Tls,
+    /// Memory
+    Memory,
+}
+
+/// Confirm the transport used by multiaddress
+pub fn find_type(addr: &Multiaddr) -> TransportType {
+    let mut iter = addr.iter();
+
+    iter.find_map(|proto| {
+        if let Protocol::Ws = proto {
+            Some(TransportType::Ws)
+        } else if let Protocol::Wss = proto {
+            Some(TransportType::Wss)
+        } else if let Protocol::Tls(_) = proto {
+            Some(TransportType::Tls)
+        } else if let Protocol::Memory(_) = proto {
+            Some(TransportType::Memory)
+        } else {
+            None
+        }
+    })
+    .unwrap_or(TransportType::Tcp)
+}
+
 #[cfg(test)]
 mod test {
     use crate::{

--- a/tentacle/tests/tcp_upgrade_mod.rs
+++ b/tentacle/tests/tcp_upgrade_mod.rs
@@ -1,0 +1,194 @@
+#![cfg(all(feature = "tls", feature = "ws"))]
+
+use futures::channel;
+use multiaddr::Protocol;
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    thread,
+};
+use tentacle::{
+    async_trait,
+    builder::{MetaBuilder, ServiceBuilder},
+    context::{ProtocolContext, ServiceContext},
+    multiaddr::Multiaddr,
+    secio::SecioKeyPair,
+    service::{ProtocolHandle, ProtocolMeta, Service, ServiceEvent, TargetProtocol, TlsConfig},
+    traits::{ServiceHandle, ServiceProtocol},
+    utils::{find_type, TransportType},
+    ProtocolId,
+};
+
+#[path = "./test_tls_dial.rs"]
+mod tls;
+
+pub fn create<F>(
+    secio: bool,
+    meta: ProtocolMeta,
+    shandle: F,
+    cert_path: String,
+) -> Service<F, SecioKeyPair>
+where
+    F: ServiceHandle + Unpin + 'static,
+{
+    let tls_config = TlsConfig::new(
+        Some(tls::make_server_config(&tls::NetConfig::example(
+            cert_path.clone(),
+        ))),
+        Some(tls::make_client_config(&tls::NetConfig::example(cert_path))),
+    );
+    let builder = ServiceBuilder::default()
+        .insert_protocol(meta)
+        .tls_config(tls_config);
+
+    if secio {
+        builder
+            .handshake_type(SecioKeyPair::secp256k1_generated().into())
+            .build(shandle)
+    } else {
+        builder.build(shandle)
+    }
+}
+
+fn create_meta(id: impl Into<ProtocolId> + Copy + Send + 'static) -> ProtocolMeta {
+    MetaBuilder::new()
+        .id(id.into())
+        .service_handle(move || {
+            if id.into() == 0.into() {
+                ProtocolHandle::None
+            } else {
+                let handle = Box::new(PHandle);
+                ProtocolHandle::Callback(handle)
+            }
+        })
+        .build()
+}
+
+struct PHandle;
+
+#[async_trait]
+impl ServiceProtocol for PHandle {
+    async fn init(&mut self, _context: &mut ProtocolContext) {}
+}
+
+struct SHandle {
+    count: Arc<Mutex<HashSet<TransportType>>>,
+}
+
+#[async_trait]
+impl ServiceHandle for SHandle {
+    async fn handle_event(&mut self, _control: &mut ServiceContext, event: ServiceEvent) {
+        if let ServiceEvent::SessionOpen { session_context } = event {
+            self.count
+                .lock()
+                .unwrap()
+                .insert(find_type(&session_context.address));
+            let _ignore = _control.disconnect(session_context.id).await;
+        }
+    }
+}
+
+fn test_tcp_upgrade_mod(secio: bool) {
+    let meta_1 = create_meta(1);
+    let meta_2 = create_meta(1);
+    let meta_3 = create_meta(1);
+    let meta_4 = create_meta(1);
+    let count = Arc::new(Mutex::new(Default::default()));
+    let shandle = SHandle {
+        count: count.clone(),
+    };
+    let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    thread::spawn(move || {
+        let multi_addr_1 = Multiaddr::from_str(
+            "/dns4/127.0.0.1/tcp/0/tls/0x09cbaa785348dabd54c61f5f9964474f7bfad7df",
+        )
+        .unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(
+            secio,
+            meta_1,
+            shandle,
+            "tests/certificates/node0/".to_string(),
+        );
+        rt.block_on(async move {
+            let tls_addr = service.listen(multi_addr_1).await.unwrap();
+            let tcp_listen = {
+                let mut tcp_listen = tls_addr.clone();
+                tcp_listen.pop();
+                tcp_listen
+            };
+            let ws_listen = {
+                let mut t = tcp_listen.clone();
+                t.push(Protocol::Ws);
+                t
+            };
+            let _ = service.listen(tcp_listen).await.unwrap();
+            let _ = service.listen(ws_listen).await.unwrap();
+            let _res = addr_sender.send(tls_addr);
+            service.run().await
+        });
+    });
+
+    let tls_addr = rt.block_on(async move { addr_receiver.await.unwrap() });
+    let tcp_listen = {
+        let mut tcp_listen = tls_addr.clone();
+        tcp_listen.pop();
+        tcp_listen
+    };
+    let ws_listen = {
+        let mut t = tcp_listen.clone();
+        t.push(Protocol::Ws);
+        t
+    };
+
+    let handle_1 = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(secio, meta_2, (), "tests/certificates/node1/".to_string());
+        rt.block_on(async move {
+            service.dial(tls_addr, TargetProtocol::All).await.unwrap();
+            service.run().await
+        });
+    });
+
+    let handle_2 = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(secio, meta_3, (), "tests/certificates/node1/".to_string());
+        rt.block_on(async move {
+            service.dial(tcp_listen, TargetProtocol::All).await.unwrap();
+            service.run().await
+        });
+    });
+
+    let handle_3 = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(secio, meta_4, (), "tests/certificates/node1/".to_string());
+        rt.block_on(async move {
+            service.dial(ws_listen, TargetProtocol::All).await.unwrap();
+            service.run().await
+        });
+    });
+
+    handle_1.join().unwrap();
+    handle_2.join().unwrap();
+    handle_3.join().unwrap();
+
+    let inner = count.lock().unwrap();
+    assert_eq!(inner.len(), 3);
+    assert_eq!(
+        &*inner,
+        &HashSet::from_iter([TransportType::Tcp, TransportType::Ws, TransportType::Tls])
+    )
+}
+
+#[test]
+fn test_tcp_upgrade_mod_tls_tcp_ws_with_secio() {
+    test_tcp_upgrade_mod(true);
+}
+
+#[test]
+fn test_tcp_upgrade_mod_tls_tcp_ws_with_no_secio() {
+    test_tcp_upgrade_mod(false);
+}

--- a/tentacle/tests/test_session_handle_open.rs
+++ b/tentacle/tests/test_session_handle_open.rs
@@ -14,8 +14,8 @@ use tentacle::{
 /// 2. open test session protocol
 /// 3. test protocol disconnect current session
 /// 4. service handle dial with dummy protocol,
-///   4.1. goto 1
-///   4.2. count >= 10, test done
+///    4.1. goto 1
+///    4.2. count >= 10, test done
 
 #[derive(Clone)]
 struct PHandle;

--- a/tentacle/tests/test_session_protocol_order.rs
+++ b/tentacle/tests/test_session_protocol_order.rs
@@ -58,12 +58,9 @@ struct SHandle {
 #[async_trait]
 impl ServiceHandle for SHandle {
     async fn handle_event(&mut self, _control: &mut ServiceContext, event: ServiceEvent) {
-        match event {
-            ServiceEvent::SessionOpen { .. } => {
-                thread::sleep(Duration::from_secs(2));
-                self.count.fetch_add(1, Ordering::SeqCst);
-            }
-            _ => (),
+        if let ServiceEvent::SessionOpen { .. } = event {
+            thread::sleep(Duration::from_secs(2));
+            self.count.fetch_add(1, Ordering::SeqCst);
         }
     }
 }

--- a/tentacle/tests/test_tls_dial.rs
+++ b/tentacle/tests/test_tls_dial.rs
@@ -130,7 +130,7 @@ pub struct NetConfig {
 }
 
 impl NetConfig {
-    fn example(node_dir: String) -> Self {
+    pub fn example(node_dir: String) -> Self {
         Self {
             server_cert_chain: Some(node_dir.clone() + "server.crt"),
             server_key: Some(node_dir.clone() + "server.key"),
@@ -238,8 +238,8 @@ fn load_private_key(filename: &str) -> PrivateKeyDer<'static> {
 
     let rsa_keys_peek = rsa_keys.next();
 
-    if rsa_keys_peek.is_some() {
-        return PrivateKeyDer::Pkcs1(rsa_keys_peek.unwrap().unwrap().clone_key());
+    if let Some(rsa_keys_peek) = rsa_keys_peek {
+        return PrivateKeyDer::Pkcs1(rsa_keys_peek.unwrap().clone_key());
     }
 
     let keyfile = fs::File::open(filename).expect("cannot open private key file");

--- a/tentacle/tests/test_tls_reconnect.rs
+++ b/tentacle/tests/test_tls_reconnect.rs
@@ -181,8 +181,8 @@ fn load_private_key(filename: &str) -> PrivateKeyDer<'static> {
 
     let rsa_keys_peek = rsa_keys.next();
 
-    if rsa_keys_peek.is_some() {
-        return PrivateKeyDer::Pkcs1(rsa_keys_peek.unwrap().unwrap().clone_key());
+    if let Some(rsa_keys_peek) = rsa_keys_peek {
+        return PrivateKeyDer::Pkcs1(rsa_keys_peek.unwrap().clone_key());
     }
 
     let keyfile = fs::File::open(filename).expect("cannot open private key file");


### PR DESCRIPTION
In the original implementation, TCP/WS/TLS could not be listened on the same port. After this PR, these protocols can be listened on the same port.