### PR TITLE
Support proxy and onion

### DIFF
--- a/multiaddr/src/onion_addr.rs
+++ b/multiaddr/src/onion_addr.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, fmt};
 
+use data_encoding::BASE32;
+
 /// Represents an Onion v3 address
 #[derive(Clone)]
 pub struct Onion3Addr<'a>(Cow<'a, [u8; 35]>, u16);
@@ -18,6 +20,11 @@ impl Onion3Addr<'_> {
     /// Consume this instance and create an owned version containing the same address
     pub fn acquire<'b>(self) -> Onion3Addr<'b> {
         Onion3Addr(Cow::Owned(self.0.into_owned()), self.1)
+    }
+
+    pub fn hash_string(&self) -> String {
+        let s = BASE32.encode(self.hash());
+        s.to_lowercase()
     }
 }
 

--- a/multiaddr/src/protocol.rs
+++ b/multiaddr/src/protocol.rs
@@ -273,8 +273,7 @@ impl fmt::Display for Protocol<'_> {
             Wss => write!(f, "/wss"),
             Memory(port) => write!(f, "/memory/{}", port),
             Onion3(addr) => {
-                let s = BASE32.encode(addr.hash());
-                write!(f, "/onion3/{}:{}", s.to_lowercase(), addr.port())
+                write!(f, "/onion3/{}:{}", addr.hash_string(), addr.port())
             }
         }
     }

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -36,6 +36,7 @@ httparse = { version = "1.9", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 
 multiaddr = { path = "../multiaddr", package = "tentacle-multiaddr", version = "0.3.4" }
+url = "2.5.4"
 molecule = "0.8.0"
 
 # upnp
@@ -48,6 +49,7 @@ tokio-rustls = { version = "0.26.0", optional = true }
 # rand 0.8 not support wasm32
 rand = "0.8"
 socket2 = { version = "0.5.0", features = ["all"] }
+fast-socks5 = "0.10.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"

--- a/tentacle/src/error.rs
+++ b/tentacle/src/error.rs
@@ -9,6 +9,9 @@ pub enum TransportErrorKind {
     /// IO error
     #[error("transport io error: `{0:?}`")]
     Io(#[from] IOError),
+    /// Proxy server error
+    #[error("proxy error: `{0:?}`")]
+    ProxyError(IOError),
     /// Protocol not support
     #[error("multiaddr `{0:?}` is not supported")]
     NotSupported(Multiaddr),

--- a/tentacle/src/runtime/mod.rs
+++ b/tentacle/src/runtime/mod.rs
@@ -14,6 +14,7 @@
     all(target_family = "wasm", feature = "wasm-timer")
 ))]
 mod generic_timer;
+pub(crate) mod proxy;
 #[cfg(all(not(target_family = "wasm"), feature = "tokio-runtime"))]
 mod tokio_runtime;
 #[cfg(target_family = "wasm")]

--- a/tentacle/src/runtime/proxy/mod.rs
+++ b/tentacle/src/runtime/proxy/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(not(target_family = "wasm"))]
+pub(crate) mod socks5;
+#[cfg(not(target_family = "wasm"))]
+pub(crate) mod socks5_config;

--- a/tentacle/src/runtime/proxy/socks5.rs
+++ b/tentacle/src/runtime/proxy/socks5.rs
@@ -1,0 +1,41 @@
+use fast_socks5::{
+    AuthenticationMethod, Socks5Command,
+    client::{Config as ConnectConfig, Socks5Stream},
+};
+use tokio::net::TcpStream;
+
+pub async fn connect(
+    socks_server: url::Url,
+    target_addr: String,
+    target_port: u16,
+) -> Result<TcpStream, fast_socks5::SocksError> {
+    let auth = {
+        if socks_server.username().is_empty() {
+            AuthenticationMethod::None
+        } else {
+            AuthenticationMethod::Password {
+                username: socks_server.username().to_string(),
+                password: socks_server.password().unwrap_or_default().to_string(),
+            }
+        }
+    };
+    let socks_server_str = format!(
+        "{}:{}",
+        socks_server.host_str().ok_or_else(|| {
+            fast_socks5::SocksError::ArgumentInputError("socks_server should have host")
+        })?,
+        socks_server.port().ok_or_else(|| {
+            fast_socks5::SocksError::ArgumentInputError("socks_server should have port")
+        })?
+    );
+    Socks5Stream::connect_raw(
+        Socks5Command::TCPConnect,
+        socks_server_str,
+        target_addr,
+        target_port,
+        Some(auth),
+        ConnectConfig::default(),
+    )
+    .await
+    .map(|socket| socket.get_socket())
+}

--- a/tentacle/src/runtime/proxy/socks5_config.rs
+++ b/tentacle/src/runtime/proxy/socks5_config.rs
@@ -1,0 +1,15 @@
+use rand::Rng;
+
+pub(crate) fn random_auth() -> (String, String) {
+    let username = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect();
+    let password = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect();
+    (username, password)
+}

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -45,7 +45,8 @@ mod helper;
 
 pub use crate::service::{
     config::{
-        HandshakeType, ProtocolHandle, ProtocolMeta, TargetProtocol, TargetSession, TcpSocket,
+        HandshakeType, ProtocolHandle, ProtocolMeta, SocketState, TargetProtocol, TargetSession,
+        TcpSocket, TransformerContext,
     },
     control::{ServiceAsyncControl, ServiceControl},
     event::{RawSessionInfo, ServiceError, ServiceEvent},

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -13,7 +13,7 @@ use std::os::{
     fd::AsFd,
     unix::io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
 };
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 #[cfg(feature = "tls")]
 use tokio_rustls::rustls::{ClientConfig, ServerConfig};
 
@@ -86,11 +86,72 @@ impl Default for SessionConfig {
     }
 }
 
-pub(crate) type TcpSocketConfig =
-    Arc<dyn Fn(TcpSocket) -> Result<TcpSocket, std::io::Error> + Send + Sync + 'static>;
+/// This enum's purpose is to let socket_transformer know how the socket is created
+pub enum SocketState {
+    /// listen
+    Listen,
+    /// dial
+    Dial,
+}
+
+/// in socket_transformer
+pub struct TransformerContext {
+    /// dial or listen
+    pub state: SocketState,
+    /// if dial, remote address; if listen, local address
+    pub address: SocketAddr,
+}
+
+impl TransformerContext {
+    /// crate a listen context
+    pub fn new_listen(address: SocketAddr) -> Self {
+        TransformerContext {
+            state: SocketState::Listen,
+            address,
+        }
+    }
+
+    /// create a dial context
+    pub fn new_dial(address: SocketAddr) -> Self {
+        TransformerContext {
+            state: SocketState::Dial,
+            address,
+        }
+    }
+}
+
+pub(crate) type TcpSocketTransformer = Arc<
+    dyn Fn(TcpSocket, TransformerContext) -> Result<TcpSocket, std::io::Error>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+#[derive(Clone)]
+pub(crate) struct TcpSocketConfig {
+    pub(crate) socket_transformer: TcpSocketTransformer,
+    pub(crate) proxy_url: Option<url::Url>,
+    pub(crate) onion_url: Option<url::Url>,
+    /// generates unique SOCKS credentials for proxy connection. Default: true
+    /// If the proxy_server is tor server, this prevents connection correlation,
+    /// and enhances privacy by forcing different Tor circuits.
+    /// see IsolateSOCKSAuth section in https://2019.www.torproject.org/docs/tor-manual.html.en
+    pub(crate) proxy_random_auth: bool,
+}
+
+impl Default for TcpSocketConfig {
+    fn default() -> Self {
+        Self {
+            socket_transformer: Arc::new(|tcp_socket, _| Ok(tcp_socket)),
+            proxy_url: None,
+            onion_url: None,
+            proxy_random_auth: true,
+        }
+    }
+}
 
 /// This config Allow users to set various underlying parameters of TCP
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct TcpConfig {
     /// When dial/listen on tcp, tentacle will call it allow user to set all tcp socket config
     pub tcp: TcpSocketConfig,
@@ -100,18 +161,6 @@ pub(crate) struct TcpConfig {
     /// When dial/listen on tls, tentacle will call it allow user to set all tcp socket config
     #[cfg(feature = "tls")]
     pub tls: TcpSocketConfig,
-}
-
-impl Default for TcpConfig {
-    fn default() -> Self {
-        TcpConfig {
-            tcp: Arc::new(Ok),
-            #[cfg(feature = "ws")]
-            ws: Arc::new(Ok),
-            #[cfg(feature = "tls")]
-            tls: Arc::new(Ok),
-        }
-    }
 }
 
 /// A TCP socket that has not yet been converted to a `TcpStream` or

--- a/tentacle/src/service/config.rs
+++ b/tentacle/src/service/config.rs
@@ -137,7 +137,7 @@ impl AsRawFd for TcpSocket {
 impl FromRawFd for TcpSocket {
     /// Converts a `RawFd` to a `TcpSocket`.
     unsafe fn from_raw_fd(fd: RawFd) -> TcpSocket {
-        let inner = socket2::Socket::from_raw_fd(fd);
+        let inner = unsafe { socket2::Socket::from_raw_fd(fd) };
         TcpSocket { inner }
     }
 }

--- a/tentacle/src/service/future_task.rs
+++ b/tentacle/src/service/future_task.rs
@@ -159,9 +159,7 @@ mod test {
                     let _res = send_task
                         .send(Box::pin(async {
                             let mut stream = pending::<()>();
-                            while let Some(_) = stream.next().await {
-                                //
-                            }
+                            while (stream.next().await).is_some() {}
                         }) as BoxedFutureTask)
                         .await;
                 }

--- a/tentacle/src/transports/onion.rs
+++ b/tentacle/src/transports/onion.rs
@@ -1,0 +1,46 @@
+use crate::{
+    multiaddr::Multiaddr,
+    runtime::TcpStream,
+    service::config::TcpSocketConfig,
+    transports::{Result, TransportDial, TransportFuture, onion_dial},
+};
+use futures::future::ok;
+use std::{future::Future, pin::Pin, time::Duration};
+
+/// Onion connect
+async fn connect(
+    onion_address: impl Future<Output = Result<Multiaddr>>,
+    timeout: Duration,
+    tcp_config: TcpSocketConfig,
+) -> Result<(Multiaddr, TcpStream)> {
+    let onion_addr = onion_address.await?;
+    let stream = onion_dial(onion_addr.clone(), tcp_config, timeout).await?;
+    Ok((onion_addr, stream))
+}
+
+/// Onion transport
+pub struct OnionTransport {
+    timeout: Duration,
+    tcp_config: TcpSocketConfig,
+}
+
+impl OnionTransport {
+    pub fn new(timeout: Duration, tcp_config: TcpSocketConfig) -> Self {
+        Self {
+            timeout,
+            tcp_config,
+        }
+    }
+}
+
+pub type OnionDialFuture =
+    TransportFuture<Pin<Box<dyn Future<Output = Result<(Multiaddr, TcpStream)>> + Send>>>;
+
+impl TransportDial for OnionTransport {
+    type DialFuture = OnionDialFuture;
+
+    fn dial(self, address: Multiaddr) -> Result<Self::DialFuture> {
+        let dial = connect(ok(address), self.timeout, self.tcp_config);
+        Ok(TransportFuture::new(Box::pin(dial)))
+    }
+}

--- a/tentacle/src/utils.rs
+++ b/tentacle/src/utils.rs
@@ -127,6 +127,8 @@ pub enum TransportType {
     Tls,
     /// Memory
     Memory,
+    /// Onion
+    Onion,
 }
 
 /// Confirm the transport used by multiaddress
@@ -142,6 +144,8 @@ pub fn find_type(addr: &Multiaddr) -> TransportType {
             Some(TransportType::Tls)
         } else if let Protocol::Memory(_) = proto {
             Some(TransportType::Memory)
+        } else if let Protocol::Onion3(_) = proto {
+            Some(TransportType::Onion)
         } else {
             None
         }

--- a/tentacle/src/utils/dns.rs
+++ b/tentacle/src/utils/dns.rs
@@ -1,4 +1,5 @@
 use futures::FutureExt;
+use log::warn;
 use std::{
     borrow::Cow,
     future::Future,
@@ -86,6 +87,9 @@ impl DnsResolver {
                     }
                     TransportType::Ws => address.push(Protocol::Ws),
                     TransportType::Wss => address.push(Protocol::Wss),
+                    TransportType::Onion => {
+                        warn!("Onion transport type should not have dns resolve")
+                    }
                 }
 
                 if let Some(peer_id) = self.peer_id.take() {


### PR DESCRIPTION
This PR introduces and supports Onion3 multiaddr for tentacle-multiaddr and adds `socks5` proxy support for tentacle dialing. It also allows tentacle to connect to a Tor server to reach an onion address.

A breaking change introduced is:
1. Changing 
   ```rust
   pub(crate) type TcpSocketConfig =
       Arc<dyn Fn(TcpSocket) -> Result<TcpSocket, std::io::Error> + Send + Sync + 'static>;
   ```
   to:
   ```rust
   pub(crate) type TcpSocketTransformer =
       Arc<dyn Fn(TcpSocket) -> Result<TcpSocket, std::io::Error> + Send + Sync + 'static>;

   pub(crate) struct TcpSocketConfig {
       pub(crate) socket_transformer: TcpSocketTransformer,
       pub(crate) proxy_config: Option<ProxyConfig>,
   }
   ```

2. Adding an `Onion` variant to the `TransportType` enum and implementing `OnionTransport`.
3. Allow `runtime::connect` to use a `socks5` proxy for connecting to the target address.
4. Add `runtime::connect_onion` to connect to a target address of the `Multiaddr` type, rather than just a `SocketAddr`, since tentacle cannot convert an onion address into a `SocketAddr`.

