### PR TITLE
feat: change by upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,7 @@ features-check:
 	# required wasm32-unknown-unknown target
 	$(Change_Work_Path) && cargo build --features wasm-timer,unstable --no-default-features --target=wasm32-unknown-unknown
 	$(Change_Work_Path) && cargo build --features wasm-timer,unstable,secio-async-trait --no-default-features --target=wasm32-unknown-unknown
-	# required wasm32-wasip1 target
-	$(Change_Work_Path) && cargo build --features wasm-timer,unstable --no-default-features --target=wasm32-wasip1
-	$(Change_Work_Path) && cargo build --features wasm-timer,unstable,secio-async-trait --no-default-features --target=wasm32-wasip1
+
 bench_p2p:
 	cd bench && cargo run --release
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.4"
 tentacle-secio = { path = "../secio" }
 tokio-yamux = { path = "../yamux" }
 rand = "0.8"

--- a/multiaddr/src/protocol.rs
+++ b/multiaddr/src/protocol.rs
@@ -20,7 +20,7 @@ const WS: u32 = 0x01dd;
 const WSS: u32 = 0x01de;
 const MEMORY: u32 = 0x0309;
 
-const SHA256_CODE: u16 = 0x12;
+const SHA256_CODE: u64 = 0x12;
 const SHA256_SIZE: u8 = 32;
 
 /// `Protocol` describes all possible multiaddress protocols.
@@ -276,7 +276,7 @@ impl<'a> From<Ipv6Addr> for Protocol<'a> {
 }
 
 fn check_p2p(data: &[u8]) -> Result<(), Error> {
-    let (code, bytes) = unsigned_varint::decode::u16(data)?;
+    let (code, bytes) = unsigned_varint::decode::u64(data)?;
 
     if code != SHA256_CODE {
         return Err(Error::UnknownHash);

--- a/secio/src/peer_id.rs
+++ b/secio/src/peer_id.rs
@@ -6,7 +6,7 @@ use unsigned_varint::{decode, encode};
 
 use crate::handshake::handshake_struct::PublicKey;
 
-const SHA256_CODE: u16 = 0x12;
+const SHA256_CODE: u64 = 0x12;
 const SHA256_SIZE: u8 = 32;
 
 /// Identifier of a peer of the network
@@ -31,7 +31,7 @@ impl PeerId {
             return Err(Error::Empty);
         }
 
-        let (code, bytes) = decode::u16(&data).map_err(|_| Error::InvalidData)?;
+        let (code, bytes) = decode::u64(&data).map_err(|_| Error::InvalidData)?;
 
         if code != SHA256_CODE {
             return Err(Error::NotSupportHashCode);
@@ -57,8 +57,8 @@ impl PeerId {
 
     /// Return `PeerId` which used hashed seed as inner.
     fn from_seed(seed: &[u8]) -> Self {
-        let mut buf = encode::u16_buffer();
-        let code = encode::u16(SHA256_CODE, &mut buf);
+        let mut buf = encode::u64_buffer();
+        let code = encode::u64(SHA256_CODE, &mut buf);
 
         let header_len = code.len() + 1;
 


### PR DESCRIPTION
The [upstream](https://github.com/multiformats/rust-multihash/commit/ebc4d859db0376dd4bf32552e78cf1d9dd7433d6) has fully encoded the hash code into u64. This PR will follow upstream changes. no break change

fuzz test break by https://github.com/rust-lang/rust/issues/135515 