### PR TITLE
multiaddr: Support Onion Protocol

### DIFF
--- a/multiaddr/Cargo.toml
+++ b/multiaddr/Cargo.toml
@@ -15,6 +15,9 @@ bytes = "1.0"
 bs58 = "0.5.0"
 sha2 = "0.10.0"
 serde = "1"
+byteorder = "1.5.0"
+data-encoding = "2.6.0"
+arrayref = "0.3.9"
 
 [dev-dependencies]
 parity-multiaddr = "0.11"

--- a/multiaddr/src/error.rs
+++ b/multiaddr/src/error.rs
@@ -5,6 +5,7 @@ use unsigned_varint::decode;
 pub enum Error {
     DataLessThanLen,
     InvalidMultiaddr,
+    InvalidOnion3Addr,
     InvalidProtocolString,
     InvalidUvar(decode::Error),
     ParsingError(Box<dyn error::Error + Send + Sync>),
@@ -19,6 +20,7 @@ impl fmt::Display for Error {
             Error::DataLessThanLen => f.write_str("we have less data than indicated by length"),
             Error::InvalidMultiaddr => f.write_str("invalid multiaddr"),
             Error::InvalidProtocolString => f.write_str("invalid protocol string"),
+            Error::InvalidOnion3Addr => f.write_str("invalid onion3 address"),
             Error::InvalidUvar(e) => write!(f, "failed to decode unsigned varint: {}", e),
             Error::ParsingError(e) => write!(f, "failed to parse: {}", e),
             Error::UnknownHash => write!(f, "unknown hash"),

--- a/multiaddr/src/lib.rs
+++ b/multiaddr/src/lib.rs
@@ -1,8 +1,10 @@
 ///! Mini Implementation of [multiaddr](https://github.com/jbenet/multiaddr) in Rust.
 mod error;
+mod onion_addr;
 mod protocol;
 
 pub use self::error::Error;
+pub use self::onion_addr::Onion3Addr;
 pub use self::protocol::Protocol;
 use bytes::{Bytes, BytesMut};
 use serde::{

--- a/multiaddr/src/onion_addr.rs
+++ b/multiaddr/src/onion_addr.rs
@@ -1,0 +1,51 @@
+use std::{borrow::Cow, fmt};
+
+/// Represents an Onion v3 address
+#[derive(Clone)]
+pub struct Onion3Addr<'a>(Cow<'a, [u8; 35]>, u16);
+
+impl<'a> Onion3Addr<'a> {
+    /// Return the hash of the public key as bytes
+    pub fn hash(&self) -> &[u8; 35] {
+        self.0.as_ref()
+    }
+
+    /// Return the port
+    pub fn port(&self) -> u16 {
+        self.1
+    }
+
+    /// Consume this instance and create an owned version containing the same address
+    pub fn acquire<'b>(self) -> Onion3Addr<'b> {
+        Onion3Addr(Cow::Owned(self.0.into_owned()), self.1)
+    }
+}
+
+impl PartialEq for Onion3Addr<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.1 == other.1 && self.0[..] == other.0[..]
+    }
+}
+
+impl Eq for Onion3Addr<'_> {}
+
+impl From<([u8; 35], u16)> for Onion3Addr<'_> {
+    fn from(parts: ([u8; 35], u16)) -> Self {
+        Self(Cow::Owned(parts.0), parts.1)
+    }
+}
+
+impl<'a> From<(&'a [u8; 35], u16)> for Onion3Addr<'a> {
+    fn from(parts: (&'a [u8; 35], u16)) -> Self {
+        Self(Cow::Borrowed(parts.0), parts.1)
+    }
+}
+
+impl fmt::Debug for Onion3Addr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_tuple("Onion3Addr")
+            .field(&format!("{:02x?}", &self.0[..]))
+            .field(&self.1)
+            .finish()
+    }
+}

--- a/multiaddr/tests/lib.rs
+++ b/multiaddr/tests/lib.rs
@@ -1,0 +1,1 @@
+mod onion;

--- a/multiaddr/tests/onion.rs
+++ b/multiaddr/tests/onion.rs
@@ -1,0 +1,54 @@
+use data_encoding::HEXUPPER;
+use std::convert::TryFrom;
+use tentacle_multiaddr::*;
+
+fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
+    let parsed = source.parse::<Multiaddr>().unwrap();
+    assert_eq!(HEXUPPER.encode(&parsed.to_vec()[..]), target);
+    assert_eq!(parsed.iter().collect::<Vec<_>>(), protocols);
+    assert_eq!(source.parse::<Multiaddr>().unwrap().to_string(), source);
+    assert_eq!(
+        Multiaddr::try_from(HEXUPPER.decode(target.as_bytes()).unwrap()).unwrap(),
+        parsed
+    );
+}
+
+#[test]
+fn construct_success() {
+    use Protocol::*;
+
+    ma_valid(
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234",
+        "BD03ADADEC040BE047F9658668B11A504F3155001F231A37F54C4476C07FB4CC139ED7E30304D2",
+        vec![Onion3(
+            (
+                [
+                    173, 173, 236, 4, 11, 224, 71, 249, 101, 134, 104, 177, 26, 80, 79, 49, 85, 0,
+                    31, 35, 26, 55, 245, 76, 68, 118, 192, 127, 180, 204, 19, 158, 215, 227, 3,
+                ],
+                1234,
+            )
+                .into(),
+        )],
+    );
+}
+
+#[test]
+fn construct_fail() {
+    let addresses = [
+        "/onion3/9ww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:80",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd7:80",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:0",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:-1",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd",
+        "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyy@:666",
+    ];
+
+    for address in &addresses {
+        assert!(
+            address.parse::<Multiaddr>().is_err(),
+            "{}",
+            address.to_string()
+        );
+    }
+}


### PR DESCRIPTION
- [x] Support Onion V3: `Onion3` variants for Protocol
- [x] Support onion address for MultiAddr

The code changes are copied from https://github.com/multiformats/rust-multiaddr/blob/master/src/onion_addr.rs

(No need to support Onion v2, it has been deprecated: https://support.torproject.org/onionservices/v2-deprecation/)
