### PR TITLE
perf: perf yamux stream read buf

### DIFF
--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -27,6 +27,7 @@ web-time = "1.1.0"
 env_logger = "0.6"
 rand = "0.8"
 bytesize = "1"
+criterion = { version = "0.3", features = ["async_tokio", "async"] }
 tokio = { version = "1.0.0", features = [
     "time",
     "net",
@@ -44,3 +45,8 @@ tokio-timer = ["tokio/time"]
 generic-timer = ["futures-timer"]
 # use futures-timer's wasm feature
 wasm = ["generic-timer", "futures-timer/wasm-bindgen"]
+
+
+[[bench]]
+name = "bench"
+harness = false

--- a/yamux/benches/bench.rs
+++ b/yamux/benches/bench.rs
@@ -1,0 +1,89 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use futures::prelude::*;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+use tokio_yamux::stream::StreamHandle;
+use tokio_yamux::{config::Config, session::Session};
+
+pub(crate) fn rt() -> &'static tokio::runtime::Runtime {
+    static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    RT.get_or_init(|| tokio::runtime::Runtime::new().unwrap())
+}
+
+fn run_server() {
+    rt().spawn(async move {
+        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+
+        while let Ok((socket, _)) = listener.accept().await {
+            let mut session = Session::new_server(socket, Config::default());
+            tokio::spawn(async move {
+                while let Some(Ok(mut stream)) = session.next().await {
+                    tokio::spawn(async move {
+                        let mut data = [0u8; 512 * 1024];
+
+                        loop {
+                            stream.read_exact(&mut data).await.unwrap();
+                            stream.write_all(&data).await.unwrap();
+                        }
+                    });
+                }
+            });
+        }
+    });
+}
+
+fn get_handle() -> &'static mut StreamHandle {
+    static mut HANDLE: std::sync::OnceLock<StreamHandle> = std::sync::OnceLock::new();
+    unsafe {
+        HANDLE.get_or_init(|| {
+            let (tx, rx) = std::sync::mpsc::channel();
+            rt().spawn(async move {
+                let socket = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+                let sa = socket.peer_addr().unwrap();
+
+                let mut session = Session::new_client(socket, Config::default());
+                let stream = session.open_stream().unwrap();
+
+                tokio::spawn(async move {
+                    loop {
+                        match session.next().await {
+                            Some(res) => log::warn!("res: {:?}", res),
+                            None => break,
+                        }
+                    }
+                    log::warn!("{:?} broken", sa);
+                });
+
+                tx.send(stream).unwrap();
+            });
+            rx.recv().unwrap()
+        });
+
+        HANDLE.get_mut().unwrap()
+    }
+}
+
+async fn bench_test(data: &[u8]) {
+    let handle = get_handle();
+    handle.write_all(data).await.unwrap();
+    let mut responed = vec![0u8; data.len()];
+    handle.read_exact(&mut responed).await.unwrap();
+    assert_eq!(&responed, data);
+}
+
+fn criterion_benchmark(bench: &mut Criterion) {
+    run_server();
+
+    let data = (0..512 * 1024)
+        .map(|_| rand::random::<u8>())
+        .collect::<Vec<_>>();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    bench.bench_with_input(BenchmarkId::new("yamux_beach", ""), &data, |b, data| {
+        b.to_async(&rt).iter(|| bench_test(data));
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
#398 use `extend_from_slice` will copy all data twice, this pr use `Vec<BytesMut>` reduces its copy from all data to just one ptr, and  Vec's memory allocation and release do not always work, because `drain` does not reclaim memory, that is, the memory allocation operation here is limited

bench master and this pr:

master branch:
```
Gnuplot not found, using plotters backend
yamux_beach/            time:   [475.10 µs 544.57 µs 618.04 µs]                         
                        change: [-5.0316% +12.625% +35.408%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```
this pr:
```
Gnuplot not found, using plotters backend
yamux_beach/            time:   [393.64 µs 451.65 µs 514.75 µs]                         
                        change: [-34.776% -23.230% -8.6939%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```