### PR TITLE
cargo: set MSRV for tentacle workspace members

### DIFF
--- a/multiaddr/Cargo.toml
+++ b/multiaddr/Cargo.toml
@@ -3,6 +3,7 @@ name = "tentacle-multiaddr"
 version = "0.3.5"
 authors = ["driftluo <driftluo@foxmail.com>"]
 edition = "2021"
+rust-version = "1.61.0"
 repository = "https://github.com/nervosnetwork/tentacle"
 license = "MIT"
 description = "Mini Implementation of multiaddr"

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/nervosnetwork/tentacle"
 keywords = ["network", "peer-to-peer"]
 categories = ["network-programming", "asynchronous"]
 edition = "2021"
+rust-version = "1.70.0"
 build = "build.rs"
 
 [package.metadata.docs.rs]

--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["network", "peer-to-peer"]
 categories = ["network-programming", "asynchronous"]
 edition = "2021"
+rust-version = "1.80.1"
 
 [package.metadata.docs.rs]
 features = ["tokio-runtime", "tokio-timer", "upnp", "ws", "unstable", "tls"]

--- a/yamux/Cargo.toml
+++ b/yamux/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
     "Nervos Core Dev <dev@nervos.org>",
 ]
 edition = "2021"
+rust-version = "1.70.0"
 
 [dependencies]
 bytes = "1.0.0"


### PR DESCRIPTION
This PR use `cargo msrv find --ignore-lockfile` found the MSRV

(`./bench/Cargo.toml` no need to set MSRV.