### PR TITLE
fix: listen drop with upgrade mode

### DIFF
--- a/tentacle/Cargo.toml
+++ b/tentacle/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0"
 nohash-hasher = "0.2"
 
 parking_lot = { version = "0.12", optional = true }
-tokio-tungstenite = { version = "0.26", optional = true }
+tokio-tungstenite = { version = "0.27", optional = true }
 httparse = { version = "1.9", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 

--- a/tentacle/src/runtime/tokio_runtime/mod.rs
+++ b/tentacle/src/runtime/tokio_runtime/mod.rs
@@ -166,8 +166,7 @@ async fn connect_by_proxy(
     socks5::connect(proxy_server_url.clone(), target_addr.clone(), target_port)
         .await
         .map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!(
                     "socks5_connect to target_addr: {}, target_port: {} by proxy_server: {} failed, err: {}",
                     target_addr, target_port, proxy_server_url, err
@@ -196,10 +195,7 @@ pub(crate) async fn connect(
         )
         .await
         .map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("connect_by_proxy: {}, error: {}", proxy_url, err),
-            )
+            io::Error::other(format!("connect_by_proxy: {}, error: {}", proxy_url, err))
         }),
         None => connect_direct(target_addr, socket_transformer).await,
     }

--- a/tentacle/src/transports/mod.rs
+++ b/tentacle/src/transports/mod.rs
@@ -20,7 +20,7 @@ mod onion;
 #[cfg(not(target_family = "wasm"))]
 mod tcp;
 #[cfg(not(target_family = "wasm"))]
-mod tcp_base_listen;
+pub(crate) mod tcp_base_listen;
 #[cfg(all(feature = "tls", not(target_family = "wasm")))]
 mod tls;
 #[cfg(all(feature = "ws", not(target_family = "wasm")))]


### PR DESCRIPTION
After #382 introduced single-port multi-protocol support, the drop listener does not handle multiple protocols. This PR fixes this issue