### PR TITLE
Fixed state transition of a stream (yamux)

### DIFF
--- a/yamux/src/stream.rs
+++ b/yamux/src/stream.rs
@@ -178,7 +178,7 @@ impl StreamHandle {
 
     fn process_flags(&mut self, flags: Flags) -> Result<(), Error> {
         if flags.contains(Flag::Ack) && self.state == StreamState::SynSent {
-            self.state = StreamState::SynReceived;
+            self.state = StreamState::Established;
         }
         if flags.contains(Flag::Fin) {
             match self.state {


### PR DESCRIPTION
Hi there

Thank you for this library (yamux). It helps me a lot.

I encountered some issues when trying to connect two peers one of them using this library and the other one using a go version. 
There were strange messages at the go side:
```
2025/07/02 12:42:31 [ERR] yamux: established stream without inflight SYN (no tracking entry)
2025/07/02 12:42:31 [ERR] yamux: established stream without inflight SYN (didn't have semaphore)
```
It continued to work as expected after this error though. But I am not sure if it is correct. Maybe some inner invariants are broken or something like that.

I dug deep into both codebases and found out that the go version receives a window frame update with an ACK flag when it is not expecting that.

Scenario:
1. tokio_yamux opens a new stream and sends a window update frame with a SYN flag to notify other side about a new incoming connection.
2. go-yamux accepts the incoming stream and sends a window update frame with an ACK flag. At this point the stream shoul d be considered as established for both sides.
3. tokio-yamux receives a window update frame with an ACK flag but for some reason it not consider stream as established and on the next window update it sends an ACK flag. 
4. go-yamux receives an ACK flag for the established stream and prints an error. 

My solution is to set the state to 'Established' after receiving an ACK flag while being in 'SynSent' state. I checked this for myself and the error was gone.