### PR TITLE
Restore yamux write-stall timeout

### DIFF
--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -264,8 +264,7 @@ where
     fn write_stalled(&self) -> bool {
         match self.write_pending_since {
             Some(since) => {
-                self.now().saturating_duration_since(since)
-                    > self.config.connection_write_timeout
+                self.now().saturating_duration_since(since) > self.config.connection_write_timeout
             }
             None => false,
         }

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -73,8 +73,12 @@ pub struct Session<T> {
     pending_streams: VecDeque<StreamHandle>,
     // The buffer which will send to underlying network
     write_pending_frames: VecDeque<Frame>,
-    // Last time the framed sink accepted an outbound frame.
-    last_send_success: Instant,
+    // When the framed sink first reported back-pressure (poll_ready/poll_flush
+    // returned Pending) without making progress since. `None` means the
+    // outbound side is currently making progress, so the stall timer is not
+    // running. The timer starts only when an outbound frame actually becomes
+    // stalled, not while the connection is merely idle.
+    write_pending_since: Option<Instant>,
     // The buffer which will distribute to sub streams
     read_pending_frames: VecDeque<Frame>,
 
@@ -181,10 +185,7 @@ where
             streams: HashMap::default(),
             pending_streams: VecDeque::default(),
             write_pending_frames: VecDeque::default(),
-            #[cfg(not(all(target_family = "wasm", not(target_os = "unknown"))))]
-            last_send_success: Instant::now(),
-            #[cfg(all(target_family = "wasm", not(target_os = "unknown")))]
-            last_send_success: Instant::from_u64(0),
+            write_pending_since: None,
             read_pending_frames: VecDeque::default(),
             event_sender,
             event_receiver,
@@ -254,9 +255,34 @@ where
         self.send_frame(cx, frame).map(|_| ping_id)
     }
 
+    /// Returns true when the outbound side has been blocked (the framed sink
+    /// kept returning `Pending`) for longer than `connection_write_timeout`.
+    ///
+    /// The stall timer is only running when `write_pending_since` is set,
+    /// i.e. a write actually became pending. An idle connection (no pending
+    /// frames, no back-pressure) is never considered stalled.
     fn write_stalled(&self) -> bool {
-        self.now().saturating_duration_since(self.last_send_success)
-            > self.config.connection_write_timeout
+        match self.write_pending_since {
+            Some(since) => {
+                self.now().saturating_duration_since(since)
+                    > self.config.connection_write_timeout
+            }
+            None => false,
+        }
+    }
+
+    /// Mark the outbound side as making progress, clearing the stall timer.
+    fn mark_write_progress(&mut self) {
+        self.write_pending_since = None;
+    }
+
+    /// Mark the outbound side as currently blocked. The first call starts the
+    /// stall timer; subsequent calls while still pending keep the original
+    /// start time.
+    fn mark_write_pending(&mut self) {
+        if self.write_pending_since.is_none() {
+            self.write_pending_since = Some(self.now());
+        }
     }
 
     /// GoAway can be used to prevent accepting further
@@ -368,12 +394,20 @@ where
             match sink.as_mut().poll_ready(cx)? {
                 Poll::Ready(()) => {
                     sink.as_mut().start_send(frame)?;
-                    self.last_send_success = self.now();
+                    // A frame was successfully accepted by the sink: the
+                    // outbound side is making progress, so reset the stall
+                    // timer.
+                    self.mark_write_progress();
                 }
                 Poll::Pending => {
                     debug!("[{:?}] framed_stream NotReady, frame: {:?}", self.ty, frame);
                     self.write_pending_frames.push_front(frame);
 
+                    // The write only just became blocked: start the stall
+                    // timer now (if it wasn't already running) and only fail
+                    // once we have actually been pending for longer than
+                    // `connection_write_timeout`.
+                    self.mark_write_pending();
                     if self.write_stalled() {
                         return Err(io::ErrorKind::TimedOut.into());
                     }
@@ -396,13 +430,21 @@ where
     fn poll_complete(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
         match Pin::new(&mut self.framed_stream).poll_flush(cx) {
             Poll::Pending => {
+                // The flush could not complete right now. Start (or keep
+                // running) the stall timer; only treat this as an error if
+                // we have actually been stalled for too long.
+                self.mark_write_pending();
                 if self.write_stalled() {
                     Err(io::ErrorKind::TimedOut.into())
                 } else {
                     Ok(true)
                 }
             }
-            Poll::Ready(res) => res.map(|_| false),
+            Poll::Ready(res) => {
+                // Flush completed: the outbound side has made progress.
+                self.mark_write_progress();
+                res.map(|_| false)
+            }
         }
     }
 
@@ -1071,10 +1113,25 @@ mod test {
             ..Default::default()
         };
         let mut session = Session::new_server(local, config);
+        // An idle session (no outbound back-pressure) must never be reported
+        // as stalled, regardless of how long it has been idle.
+        assert!(!session.write_stalled());
+        assert!(session.write_pending_since.is_none());
+
+        // Simulate the sink reporting back-pressure: the stall timer starts
+        // now, but the connection is not stalled yet.
+        session.mark_write_pending();
         assert!(!session.write_stalled());
 
-        session.last_send_success = session.now() - Duration::from_secs(1);
+        // Pretend back-pressure has lasted longer than the configured
+        // timeout: only now should we report stalled.
+        session.write_pending_since = Some(session.now() - Duration::from_secs(1));
         assert!(session.write_stalled());
+
+        // Once the sink makes progress again, the stall timer must be reset.
+        session.mark_write_progress();
+        assert!(!session.write_stalled());
+        assert!(session.write_pending_since.is_none());
     }
 
     #[test]

--- a/yamux/src/session.rs
+++ b/yamux/src/session.rs
@@ -73,6 +73,8 @@ pub struct Session<T> {
     pending_streams: VecDeque<StreamHandle>,
     // The buffer which will send to underlying network
     write_pending_frames: VecDeque<Frame>,
+    // Last time the framed sink accepted an outbound frame.
+    last_send_success: Instant,
     // The buffer which will distribute to sub streams
     read_pending_frames: VecDeque<Frame>,
 
@@ -179,6 +181,10 @@ where
             streams: HashMap::default(),
             pending_streams: VecDeque::default(),
             write_pending_frames: VecDeque::default(),
+            #[cfg(not(all(target_family = "wasm", not(target_os = "unknown"))))]
+            last_send_success: Instant::now(),
+            #[cfg(all(target_family = "wasm", not(target_os = "unknown")))]
+            last_send_success: Instant::from_u64(0),
             read_pending_frames: VecDeque::default(),
             event_sender,
             event_receiver,
@@ -246,6 +252,11 @@ where
         };
         let frame = Frame::new_ping(Flags::from(flag), ping_id);
         self.send_frame(cx, frame).map(|_| ping_id)
+    }
+
+    fn write_stalled(&self) -> bool {
+        self.now().saturating_duration_since(self.last_send_success)
+            > self.config.connection_write_timeout
     }
 
     /// GoAway can be used to prevent accepting further
@@ -357,10 +368,15 @@ where
             match sink.as_mut().poll_ready(cx)? {
                 Poll::Ready(()) => {
                     sink.as_mut().start_send(frame)?;
+                    self.last_send_success = self.now();
                 }
                 Poll::Pending => {
                     debug!("[{:?}] framed_stream NotReady, frame: {:?}", self.ty, frame);
                     self.write_pending_frames.push_front(frame);
+
+                    if self.write_stalled() {
+                        return Err(io::ErrorKind::TimedOut.into());
+                    }
 
                     if self.poll_complete(cx)? {
                         return Ok(true);
@@ -379,7 +395,13 @@ where
     /// Sink `poll_complete` NotReady -> there is more work left to do, may wake up next poll
     fn poll_complete(&mut self, cx: &mut Context) -> Result<bool, io::Error> {
         match Pin::new(&mut self.framed_stream).poll_flush(cx) {
-            Poll::Pending => Ok(true),
+            Poll::Pending => {
+                if self.write_stalled() {
+                    Err(io::ErrorKind::TimedOut.into())
+                } else {
+                    Ok(true)
+                }
+            }
             Poll::Ready(res) => res.map(|_| false),
         }
     }
@@ -1040,6 +1062,21 @@ mod test {
     }
 
     // after TIMEOUT time, will finished
+    #[test]
+    fn test_write_stalled_uses_connection_write_timeout() {
+        let (_remote, local) = MockSocket::new();
+        let config = Config {
+            enable_keepalive: false,
+            connection_write_timeout: Duration::from_millis(1),
+            ..Default::default()
+        };
+        let mut session = Session::new_server(local, config);
+        assert!(!session.write_stalled());
+
+        session.last_send_success = session.now() - Duration::from_secs(1);
+        assert!(session.write_stalled());
+    }
+
     #[test]
     fn test_keepalive_should_work_on_no_communication_scenario() {
         let rt = rt();


### PR DESCRIPTION
## Summary

Restore write-stall timeout enforcement for yamux sessions.

When the underlying framed sink cannot make progress, outbound frames can remain queued while a peer continues sending inbound control frames. This change tracks the last time an outbound frame was accepted by the framed sink and fails the session with `TimedOut` if writes remain stalled longer than `connection_write_timeout`.

## Changes

- Track `last_send_success` in `Session`.
- Update it after successful `start_send`.
- Return `TimedOut` when `poll_ready` or `poll_flush` remain pending past `connection_write_timeout`.
- Add regression coverage for the write-stall timeout calculation.

## Testing

- `cargo fmt`
- `cargo test -p tokio-yamux`