### PR TITLE
Enforce global budget for service task backpressure

### DIFF
--- a/tentacle/src/context.rs
+++ b/tentacle/src/context.rs
@@ -17,8 +17,8 @@ use crate::{
     multiaddr::Multiaddr,
     secio::PublicKey,
     service::{
-        ServiceAsyncControl, ServiceControl, SessionType, TargetProtocol, TargetSession,
-        event::ServiceTask,
+        ServiceAsyncControl, ServiceControl, ServiceTaskBudget, SessionType, TargetProtocol,
+        TargetSession, event::ServiceTask,
     },
     session::SessionEvent,
 };
@@ -123,9 +123,13 @@ pub struct ServiceContext {
 
 impl ServiceContext {
     /// New
-    pub(crate) fn new(task_sender: mpsc::Sender<ServiceTask>, closed: Arc<AtomicBool>) -> Self {
+    pub(crate) fn new(
+        task_sender: mpsc::Sender<ServiceTask>,
+        closed: Arc<AtomicBool>,
+        task_budget: ServiceTaskBudget,
+    ) -> Self {
         ServiceContext {
-            inner: ServiceControl::new(task_sender, closed).into(),
+            inner: ServiceControl::new(task_sender, closed, task_budget).into(),
             listens: Vec::new(),
         }
     }

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -836,7 +836,10 @@ mod tests {
         multiaddr::Multiaddr,
         quic::{config::QuicConfig, endpoint::QuicEndpoint},
         secio::SecioKeyPair,
-        service::{ServiceAsyncControl, ServiceControl, SessionType, config::SessionConfig},
+        service::{
+            ServiceAsyncControl, ServiceControl, ServiceTaskBudget, SessionType,
+            config::SessionConfig,
+        },
         session::SessionMeta,
     };
     use futures::channel::mpsc as fmpsc;
@@ -847,8 +850,12 @@ mod tests {
     fn dummy_meta(ctx: Arc<SessionContext>) -> SessionMeta {
         let (event_sender, _event_receiver) = priority_mpsc::channel(8);
         let (task_sender, _task_receiver) = priority_mpsc::channel(8);
-        let service_control: ServiceAsyncControl =
-            ServiceControl::new(task_sender, Arc::new(AtomicBool::new(false))).into();
+        let service_control: ServiceAsyncControl = ServiceControl::new(
+            task_sender,
+            Arc::new(AtomicBool::new(false)),
+            ServiceTaskBudget::new(8),
+        )
+        .into();
         SessionMeta::new(Duration::from_secs(60), ctx, event_sender, service_control)
             .config(SessionConfig::default())
     }

--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -53,6 +53,7 @@ pub(crate) mod event;
 pub(crate) mod future_task;
 mod helper;
 
+pub(crate) use crate::service::control::ServiceTaskBudget;
 pub use crate::service::{
     config::{
         HandshakeType, ProtocolHandle, ProtocolMeta, SocketState, TargetProtocol, TargetSession,
@@ -150,6 +151,7 @@ struct InnerService<K> {
     service_context: ServiceContext,
     /// External event receiver
     service_task_receiver: priority_mpsc::Receiver<ServiceTask>,
+    service_task_budget: ServiceTaskBudget,
 
     shutdown: Arc<AtomicBool>,
 
@@ -189,6 +191,7 @@ where
             mpsc::channel(config.session_config.channel_size);
         let (task_sender, task_receiver) =
             priority_mpsc::channel(config.session_config.channel_size);
+        let service_task_budget = ServiceTaskBudget::new(config.session_config.channel_size);
         let (future_task_sender, future_task_receiver) =
             mpsc::channel(config.session_config.channel_size);
         let (user_handle_sender, user_handle_receiver) =
@@ -201,7 +204,8 @@ where
             None
         };
 
-        let service_context = ServiceContext::new(task_sender, shutdown.clone());
+        let service_context =
+            ServiceContext::new(task_sender, shutdown.clone(), service_task_budget.clone());
 
         // QUIC endpoint is built up-front (binding nothing) so that listen /
         // dial calls can clone it. Each `(HandshakeType, quic_config)`
@@ -278,6 +282,7 @@ where
                 service_context,
                 config,
                 service_task_receiver: task_receiver,
+                service_task_budget,
                 shutdown,
                 wait_handle: Vec::new(),
             }),
@@ -1822,6 +1827,9 @@ where
                     self.handle_session_event(event).await
                 },
                 Some((priority, task)) = self.service_task_receiver.next() => {
+                    if task.counts_against_budget() {
+                        self.service_task_budget.release();
+                    }
                     self.handle_service_task(task, priority).await
                 }
             }

--- a/tentacle/src/service/control.rs
+++ b/tentacle/src/service/control.rs
@@ -1,7 +1,10 @@
 use futures::prelude::*;
 
 use std::fmt::Debug;
-use std::sync::{Arc, atomic::Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::time::Duration;
 
 use crate::{
@@ -15,23 +18,77 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use std::sync::atomic::AtomicBool;
 
 type Result = std::result::Result<(), SendErrorKind>;
+
+#[derive(Clone)]
+pub(crate) struct ServiceTaskBudget {
+    limit: usize,
+    queued: Arc<AtomicUsize>,
+}
+
+impl ServiceTaskBudget {
+    pub(crate) fn new(limit: usize) -> Self {
+        ServiceTaskBudget {
+            limit,
+            queued: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn acquire(&self) -> Result {
+        let mut current = self.queued.load(Ordering::Acquire);
+        loop {
+            if current >= self.limit {
+                return Err(SendErrorKind::WouldBlock);
+            }
+            match self.queued.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    pub(crate) fn release(&self) {
+        self.queued.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn acquire_task_budget(
+    event: &ServiceTask,
+    budget: &ServiceTaskBudget,
+) -> std::result::Result<bool, SendErrorKind> {
+    if event.counts_against_budget() {
+        budget.acquire()?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
 
 /// Service control, used to send commands externally at runtime
 #[derive(Clone)]
 pub struct ServiceControl {
     pub(crate) task_sender: mpsc::Sender<ServiceTask>,
     closed: Arc<AtomicBool>,
+    task_budget: ServiceTaskBudget,
 }
 
 impl ServiceControl {
     /// New
-    pub(crate) fn new(task_sender: mpsc::Sender<ServiceTask>, closed: Arc<AtomicBool>) -> Self {
+    pub(crate) fn new(
+        task_sender: mpsc::Sender<ServiceTask>,
+        closed: Arc<AtomicBool>,
+        task_budget: ServiceTaskBudget,
+    ) -> Self {
         ServiceControl {
             task_sender,
             closed,
+            task_budget,
         }
     }
 
@@ -40,7 +97,11 @@ impl ServiceControl {
         if self.closed.load(Ordering::SeqCst) {
             return Err(SendErrorKind::BrokenPipe);
         }
+        let acquired_budget = acquire_task_budget(&event, &self.task_budget)?;
         self.task_sender.try_send(event).map_err(|err| {
+            if acquired_budget {
+                self.task_budget.release();
+            }
             if err.is_full() {
                 SendErrorKind::WouldBlock
             } else {
@@ -55,7 +116,11 @@ impl ServiceControl {
         if self.closed.load(Ordering::SeqCst) {
             return Err(SendErrorKind::BrokenPipe);
         }
+        let acquired_budget = acquire_task_budget(&event, &self.task_budget)?;
         self.task_sender.try_quick_send(event).map_err(|err| {
+            if acquired_budget {
+                self.task_budget.release();
+            }
             if err.is_full() {
                 SendErrorKind::WouldBlock
             } else {
@@ -265,6 +330,7 @@ impl From<ServiceControl> for ServiceAsyncControl {
         ServiceAsyncControl {
             task_sender: control.task_sender,
             closed: control.closed,
+            task_budget: control.task_budget,
         }
     }
 }
@@ -274,6 +340,7 @@ impl From<ServiceAsyncControl> for ServiceControl {
         ServiceControl {
             task_sender: control.task_sender,
             closed: control.closed,
+            task_budget: control.task_budget,
         }
     }
 }
@@ -295,6 +362,7 @@ impl Debug for ServiceAsyncControl {
 pub struct ServiceAsyncControl {
     task_sender: mpsc::Sender<ServiceTask>,
     closed: Arc<AtomicBool>,
+    task_budget: ServiceTaskBudget,
 }
 
 impl ServiceAsyncControl {
@@ -303,7 +371,11 @@ impl ServiceAsyncControl {
         if self.closed.load(Ordering::SeqCst) {
             return Err(SendErrorKind::BrokenPipe);
         }
+        let acquired_budget = acquire_task_budget(&event, &self.task_budget)?;
         self.task_sender.async_send(event).await.map_err(|_err| {
+            if acquired_budget {
+                self.task_budget.release();
+            }
             // await only return err when channel close
             SendErrorKind::BrokenPipe
         })
@@ -315,10 +387,14 @@ impl ServiceAsyncControl {
         if self.closed.load(Ordering::SeqCst) {
             return Err(SendErrorKind::BrokenPipe);
         }
+        let acquired_budget = acquire_task_budget(&event, &self.task_budget)?;
         self.task_sender
             .async_quick_send(event)
             .await
             .map_err(|_err| {
+                if acquired_budget {
+                    self.task_budget.release();
+                }
                 // await only return err when channel close
                 SendErrorKind::BrokenPipe
             })
@@ -531,5 +607,340 @@ impl ServiceAsyncControl {
     /// Shutdown service, don't care anything, may cause partial message loss
     pub async fn shutdown(&self) -> Result {
         self.quick_send(ServiceTask::Shutdown(true)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::mpsc as priority_mpsc;
+
+    /// Build a control plus its keep-alive receiver. The receiver must be kept
+    /// in scope by the caller; dropping it would close the channel and turn
+    /// every subsequent send into a `BrokenPipe` error.
+    fn make_control(
+        channel_buf: usize,
+        budget_limit: usize,
+    ) -> (
+        ServiceControl,
+        ServiceTaskBudget,
+        priority_mpsc::Receiver<ServiceTask>,
+    ) {
+        let (sender, receiver) = priority_mpsc::channel(channel_buf);
+        let budget = ServiceTaskBudget::new(budget_limit);
+        let control = ServiceControl::new(sender, Arc::new(AtomicBool::new(false)), budget.clone());
+        (control, budget, receiver)
+    }
+
+    fn protocol_msg() -> ServiceTask {
+        ServiceTask::ProtocolMessage {
+            target: TargetSession::All,
+            proto_id: 1.into(),
+            data: Bytes::new(),
+        }
+    }
+
+    #[test]
+    fn service_task_budget_is_shared_by_control_clones() {
+        // Channel must have enough capacity to admit the budget'd ProtocolMessage
+        // plus the un-counted Shutdown task. With buffer=1 and 1 base sender + 1
+        // clone, the channel capacity is buffer + num_senders = 3, which is enough.
+        let (control, budget, _receiver) = make_control(1, 1);
+        let cloned = control.clone();
+
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+        // close() sends Shutdown, which is NOT counted against the budget but
+        // still occupies a channel slot.
+        assert!(control.close().is_ok());
+        assert!(matches!(
+            cloned.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+            Err(SendErrorKind::WouldBlock)
+        ));
+
+        budget.release();
+        assert!(
+            cloned
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+    }
+
+    /// `counts_against_budget()` must only return `true` for the resource-
+    /// heavy task variants. Adding new variants in the future without
+    /// updating this mapping would be a silent regression of the fix.
+    /// (`RawSession` is omitted because it requires a real `AsyncRw`.)
+    #[test]
+    fn counts_against_budget_classification() {
+        assert!(protocol_msg().counts_against_budget());
+        assert!(
+            ServiceTask::FutureTask {
+                task: Box::pin(async {}),
+            }
+            .counts_against_budget()
+        );
+
+        // None of the control-plane / lifecycle variants should be metered.
+        let non_counted: Vec<ServiceTask> = vec![
+            ServiceTask::ProtocolOpen {
+                session_id: 1.into(),
+                target: TargetProtocol::Single(1.into()),
+            },
+            ServiceTask::ProtocolClose {
+                session_id: 1.into(),
+                proto_id: 1.into(),
+            },
+            ServiceTask::SetProtocolNotify {
+                proto_id: 1.into(),
+                interval: Duration::from_secs(1),
+                token: 0,
+            },
+            ServiceTask::RemoveProtocolNotify {
+                proto_id: 1.into(),
+                token: 0,
+            },
+            ServiceTask::SetProtocolSessionNotify {
+                session_id: 1.into(),
+                proto_id: 1.into(),
+                interval: Duration::from_secs(1),
+                token: 0,
+            },
+            ServiceTask::RemoveProtocolSessionNotify {
+                session_id: 1.into(),
+                proto_id: 1.into(),
+                token: 0,
+            },
+            ServiceTask::Disconnect {
+                session_id: 1.into(),
+            },
+            ServiceTask::Dial {
+                address: "/ip4/127.0.0.1/tcp/1".parse().unwrap(),
+                target: TargetProtocol::All,
+            },
+            ServiceTask::Listen {
+                address: "/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+            },
+            ServiceTask::Shutdown(false),
+            ServiceTask::Shutdown(true),
+        ];
+        for task in non_counted {
+            assert!(
+                !task.counts_against_budget(),
+                "task should not be counted: {:?}",
+                task
+            );
+        }
+    }
+
+    /// Non-counted control tasks must not consume budget even when the
+    /// budget is already saturated. This guards against control-plane
+    /// starvation.
+    #[test]
+    fn non_counted_tasks_bypass_budget_even_when_full() {
+        let (control, _budget, _receiver) = make_control(8, 1);
+
+        // Exhaust the budget with a counted task.
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+        assert!(matches!(
+            control.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+            Err(SendErrorKind::WouldBlock)
+        ));
+
+        // Control-plane tasks must still go through.
+        assert!(control.open_protocol(1.into(), 1.into()).is_ok());
+        assert!(control.close_protocol(1.into(), 1.into()).is_ok());
+        assert!(control.disconnect(1.into()).is_ok());
+        assert!(
+            control
+                .set_service_notify(1.into(), Duration::from_secs(1), 0)
+                .is_ok()
+        );
+        assert!(control.close().is_ok());
+    }
+
+    /// When the underlying channel rejects a send (e.g. because the per-sender
+    /// guaranteed slot is already in use), the optimistically-acquired budget
+    /// slot must be released so it doesn't leak.
+    #[test]
+    fn budget_is_released_when_underlying_channel_send_fails() {
+        // buffer=0 + 1 sender => channel capacity = 1.
+        let (sender, _receiver) = priority_mpsc::channel(0);
+        let budget = ServiceTaskBudget::new(8);
+        let control = ServiceControl::new(sender, Arc::new(AtomicBool::new(false)), budget.clone());
+
+        // First send fills the single channel slot.
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+        assert_eq!(budget.queued.load(Ordering::Acquire), 1);
+
+        // Channel is now full for this sender => try_send returns Full.
+        // The wrapper must translate to WouldBlock AND release the budget.
+        assert!(matches!(
+            control.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+            Err(SendErrorKind::WouldBlock)
+        ));
+        assert_eq!(
+            budget.queued.load(Ordering::Acquire),
+            1,
+            "failed send must not retain its optimistic budget slot",
+        );
+    }
+
+    /// When the service is already closed, the budget must not be acquired at
+    /// all. Otherwise repeated post-close sends would slowly inflate the
+    /// counter.
+    #[test]
+    fn closed_service_does_not_acquire_budget() {
+        let (sender, _receiver) = priority_mpsc::channel(8);
+        let budget = ServiceTaskBudget::new(4);
+        let closed = Arc::new(AtomicBool::new(true));
+        let control = ServiceControl::new(sender, closed, budget.clone());
+
+        for _ in 0..16 {
+            assert!(matches!(
+                control.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+                Err(SendErrorKind::BrokenPipe)
+            ));
+        }
+        assert_eq!(budget.queued.load(Ordering::Acquire), 0);
+    }
+
+    /// Directly models the finding's attack scenario: many cloned
+    /// `ServiceControl` senders (mimicking per-session `ServiceContext`
+    /// clones) must NOT be able to enqueue more counted tasks than the
+    /// budget limit, regardless of how many clones exist.
+    #[test]
+    fn many_clones_cannot_exceed_budget_limit() {
+        const LIMIT: usize = 4;
+        const CLONES: usize = 64;
+        // Channel large enough that channel capacity is not the limiting factor.
+        let (sender, _receiver) = priority_mpsc::channel(1024);
+        let budget = ServiceTaskBudget::new(LIMIT);
+        let control = ServiceControl::new(sender, Arc::new(AtomicBool::new(false)), budget.clone());
+
+        let clones: Vec<_> = (0..CLONES).map(|_| control.clone()).collect();
+
+        let mut accepted = 0usize;
+        // Each clone tries to push 2 tasks; total attempts = 128 >> LIMIT.
+        for c in &clones {
+            for _ in 0..2 {
+                if c.filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                    .is_ok()
+                {
+                    accepted += 1;
+                }
+            }
+        }
+
+        assert_eq!(
+            accepted, LIMIT,
+            "budget must cap aggregate counted-task admission to LIMIT regardless of sender clones",
+        );
+        assert_eq!(budget.queued.load(Ordering::Acquire), LIMIT);
+    }
+
+    /// Simulates the service loop's behaviour: dequeueing a counted task must
+    /// release its budget slot so further sends can succeed.
+    #[test]
+    fn service_loop_dequeue_release_pattern_frees_budget() {
+        let (sender, mut receiver) = priority_mpsc::channel(8);
+        let budget = ServiceTaskBudget::new(2);
+        let control = ServiceControl::new(sender, Arc::new(AtomicBool::new(false)), budget.clone());
+
+        // Fill the budget.
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+        assert!(matches!(
+            control.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+            Err(SendErrorKind::WouldBlock)
+        ));
+
+        // Simulate one service-loop iteration: pull a task and release if it
+        // counts against the budget (mirrors service.rs:1829-1833).
+        let (_priority, task) = receiver.try_next().expect("queued task").expect("some task");
+        assert!(task.counts_against_budget());
+        budget.release();
+
+        // The freshly-released slot must let the next send succeed.
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+    }
+
+    /// `ServiceControl` <-> `ServiceAsyncControl` conversions must preserve
+    /// the shared `Arc<AtomicUsize>` counter so async paths are also covered.
+    #[test]
+    fn async_control_conversion_preserves_shared_budget() {
+        let (control, budget, _receiver) = make_control(8, 1);
+        let async_control: ServiceAsyncControl = control.clone().into();
+
+        // Saturate via the sync control.
+        assert!(
+            control
+                .filter_broadcast(TargetSession::All, 1.into(), Bytes::new())
+                .is_ok()
+        );
+
+        // The async control's acquire path must also see the saturated budget.
+        let evt = protocol_msg();
+        assert!(matches!(
+            acquire_task_budget(&evt, &async_control.task_budget),
+            Err(SendErrorKind::WouldBlock)
+        ));
+
+        budget.release();
+        assert!(acquire_task_budget(&evt, &async_control.task_budget).is_ok());
+    }
+
+    /// Direct unit tests on `ServiceTaskBudget` boundary behaviour.
+    #[test]
+    fn budget_acquire_release_boundaries() {
+        let b = ServiceTaskBudget::new(3);
+        assert!(b.acquire().is_ok());
+        assert!(b.acquire().is_ok());
+        assert!(b.acquire().is_ok());
+        assert!(matches!(b.acquire(), Err(SendErrorKind::WouldBlock)));
+        b.release();
+        assert!(b.acquire().is_ok());
+        // Drain.
+        b.release();
+        b.release();
+        b.release();
+        assert_eq!(b.queued.load(Ordering::Acquire), 0);
+    }
+
+    /// A zero-limit budget should reject every counted task while still letting
+    /// non-counted control tasks pass through.
+    #[test]
+    fn zero_limit_budget_blocks_counted_admits_non_counted() {
+        let (sender, _receiver) = priority_mpsc::channel(8);
+        let budget = ServiceTaskBudget::new(0);
+        let control = ServiceControl::new(sender, Arc::new(AtomicBool::new(false)), budget);
+
+        assert!(matches!(
+            control.filter_broadcast(TargetSession::All, 1.into(), Bytes::new()),
+            Err(SendErrorKind::WouldBlock)
+        ));
+        assert!(control.open_protocol(1.into(), 1.into()).is_ok());
     }
 }

--- a/tentacle/src/service/control.rs
+++ b/tentacle/src/service/control.rs
@@ -875,7 +875,10 @@ mod tests {
 
         // Simulate one service-loop iteration: pull a task and release if it
         // counts against the budget (mirrors service.rs:1829-1833).
-        let (_priority, task) = receiver.try_next().expect("queued task").expect("some task");
+        let (_priority, task) = receiver
+            .try_next()
+            .expect("queued task")
+            .expect("some task");
         assert!(task.counts_against_budget());
         budget.release();
 

--- a/tentacle/src/service/event.rs
+++ b/tentacle/src/service/event.rs
@@ -242,6 +242,15 @@ pub(crate) enum ServiceTask {
     Shutdown(bool),
 }
 
+impl ServiceTask {
+    pub(crate) fn counts_against_budget(&self) -> bool {
+        matches!(
+            self,
+            ServiceTask::ProtocolMessage { .. } | ServiceTask::FutureTask { .. }
+        )
+    }
+}
+
 /// Raw session info
 pub enum RawSessionInfo {
     /// Inbound session


### PR DESCRIPTION
## Summary

- Add a shared service-task budget across all `ServiceControl` clones
- Enforce the budget for queued `ProtocolMessage` and `FutureTask` tasks
- Release the budget when `InnerService` receives a queued service task
- Keep control events such as shutdown, disconnect, and protocol close flowing
- Add regression coverage for cloned controls sharing the same budget

## Motivation

The bounded priority channel has capacity `buffer + num_senders`, so cloning `ServiceControl` could increase the effective service task queue capacity.

Since `ServiceContext` is cloned into per-session protocol handlers, remote-created sessions could indirectly create more senders and weaken the intended aggregate backpressure boundary.

## Testing

- `cargo fmt --check`
- `cargo test -p tentacle service_task_budget_is_shared_by_control_clones`