### PR TITLE
Apply service frame limit to WebSocket handshakes

### DIFF
--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -259,6 +259,7 @@ where
                         config.timeout,
                         config.tcp_config.clone(),
                         config.trusted_proxies.clone(),
+                        config.max_frame_length,
                     );
                     #[cfg(feature = "tls")]
                     let transport = transport.tls_config(config.tls_config.clone());

--- a/tentacle/src/transports/mod.rs
+++ b/tentacle/src/transports/mod.rs
@@ -145,6 +145,7 @@ mod os {
         pub(crate) tls_config: Option<TlsConfig>,
         /// Trusted proxy addresses for HAProxy PROXY protocol and X-Forwarded-For header parsing.
         pub(crate) trusted_proxies: Arc<Vec<std::net::IpAddr>>,
+        pub(crate) max_frame_length: usize,
     }
 
     impl MultiTransport {
@@ -152,6 +153,7 @@ mod os {
             timeout: ServiceTimeout,
             tcp_config: TcpConfig,
             trusted_proxies: Vec<std::net::IpAddr>,
+            max_frame_length: usize,
         ) -> Self {
             MultiTransport {
                 timeout,
@@ -160,6 +162,7 @@ mod os {
                 #[cfg(feature = "tls")]
                 tls_config: None,
                 trusted_proxies: Arc::new(trusted_proxies),
+                max_frame_length,
             }
         }
 
@@ -246,7 +249,13 @@ mod os {
                 }
                 #[cfg(feature = "ws")]
                 TransportType::Ws => {
-                    match WsTransport::new(self.timeout.timeout, self.tcp_config.ws).dial(address) {
+                    match WsTransport::new(
+                        self.timeout.timeout,
+                        self.tcp_config.ws,
+                        self.max_frame_length,
+                    )
+                    .dial(address)
+                    {
                         Ok(future) => Ok(MultiDialFuture::Ws(future)),
                         Err(e) => Err(e),
                     }

--- a/tentacle/src/transports/tcp.rs
+++ b/tentacle/src/transports/tcp.rs
@@ -45,6 +45,7 @@ pub struct TcpTransport {
     tls_config: TlsConfig,
     /// Trusted proxy addresses for HAProxy PROXY protocol and X-Forwarded-For header parsing.
     trusted_proxies: Arc<Vec<std::net::IpAddr>>,
+    max_frame_length: usize,
 }
 
 impl TcpTransport {
@@ -57,6 +58,7 @@ impl TcpTransport {
             #[cfg(feature = "tls")]
             tls_config: Default::default(),
             trusted_proxies: Arc::new(Vec::new()),
+            max_frame_length: crate::service::config::ServiceConfig::default().max_frame_length,
         }
     }
 
@@ -78,6 +80,7 @@ impl TcpTransport {
             #[cfg(feature = "tls")]
             tls_config: multi_transport.tls_config.unwrap_or_default(),
             trusted_proxies: multi_transport.trusted_proxies,
+            max_frame_length: multi_transport.max_frame_length,
         }
     }
 }
@@ -105,6 +108,7 @@ impl TransportListen for TcpTransport {
                     self.global,
                     self.timeout,
                     self.trusted_proxies,
+                    self.max_frame_length,
                 );
                 Ok(TransportFuture::new(Box::pin(task)))
             }
@@ -118,6 +122,7 @@ impl TransportListen for TcpTransport {
                     self.global,
                     self.timeout,
                     self.trusted_proxies,
+                    self.max_frame_length,
                 );
                 Ok(TransportFuture::new(Box::pin(task)))
             }

--- a/tentacle/src/transports/tcp_base_listen.rs
+++ b/tentacle/src/transports/tcp_base_listen.rs
@@ -21,7 +21,10 @@ use log::debug;
 #[cfg(any(feature = "ws", feature = "tls"))]
 use crate::multiaddr::Protocol;
 #[cfg(feature = "ws")]
-use {crate::transports::ws::WsStream, tokio_tungstenite::accept_async};
+use {
+    crate::transports::ws::{WsStream, websocket_config},
+    tokio_tungstenite::accept_async_with_config,
+};
 #[cfg(feature = "tls")]
 use {
     crate::{service::TlsConfig, transports::parse_tls_domain_name},
@@ -55,6 +58,7 @@ pub async fn bind(
     global: Arc<crate::lock::Mutex<HashMap<SocketAddr, UpgradeMode>>>,
     timeout: Duration,
     trusted_proxies: Arc<Vec<IpAddr>>,
+    max_frame_length: usize,
 ) -> Result<(Multiaddr, TcpBaseListenerEnum)> {
     let addr = address.await?;
     let upgrade_mode: UpgradeMode = listen_mode.into();
@@ -141,6 +145,7 @@ pub async fn bind(
                         upgrade_mode,
                         global,
                         trusted_proxies,
+                        max_frame_length,
                     );
                     #[cfg(feature = "tls")]
                     let tcp_listen = tcp_listen.tls_config(tls_server_config);
@@ -247,6 +252,7 @@ pub struct TcpBaseListener {
     tls_config: Arc<ServerConfig>,
     /// Trusted proxy addresses for HAProxy PROXY protocol and X-Forwarded-For header parsing.
     trusted_proxies: Arc<Vec<IpAddr>>,
+    max_frame_length: usize,
 }
 
 impl Drop for TcpBaseListener {
@@ -263,6 +269,7 @@ impl TcpBaseListener {
         upgrade_mode: UpgradeMode,
         global: Arc<crate::lock::Mutex<HashMap<SocketAddr, UpgradeMode>>>,
         trusted_proxies: Arc<Vec<IpAddr>>,
+        max_frame_length: usize,
     ) -> Self {
         let (tx, rx) = mpsc::channel(128);
 
@@ -281,6 +288,7 @@ impl TcpBaseListener {
                     .with_cert_resolver(Arc::new(ResolvesServerCertUsingSni::new())),
             ),
             trusted_proxies,
+            max_frame_length,
         }
     }
 
@@ -309,6 +317,7 @@ impl TcpBaseListener {
                         let sender = self.sender.clone();
                         let upgrade_mode = self.upgrade_mode.to_enum();
                         let trusted_proxies = Arc::clone(&self.trusted_proxies);
+                        let max_frame_length = self.max_frame_length;
                         #[cfg(feature = "tls")]
                         let acceptor = TlsAcceptor::from(Arc::clone(&self.tls_config));
                         crate::runtime::spawn(protocol_select(
@@ -318,6 +327,7 @@ impl TcpBaseListener {
                             sender,
                             remote_address,
                             trusted_proxies,
+                            max_frame_length,
                             #[cfg(feature = "tls")]
                             acceptor,
                         ));
@@ -363,6 +373,7 @@ async fn protocol_select(
     mut sender: Sender<(Multiaddr, MultiStream)>,
     #[allow(unused_mut)] mut remote_address: SocketAddr,
     trusted_proxies: Arc<Vec<IpAddr>>,
+    #[allow(unused_variables)] max_frame_length: usize,
     #[cfg(feature = "tls")] acceptor: TlsAcceptor,
 ) {
     let mut peek_buf = [0u8; 16];
@@ -429,7 +440,12 @@ async fn protocol_select(
                         extract_forwarded_for_from_ws_handshake(&stream, remote_address).await;
                 }
 
-                match crate::runtime::timeout(timeout, accept_async(stream)).await {
+                match crate::runtime::timeout(
+                    timeout,
+                    accept_async_with_config(stream, Some(websocket_config(max_frame_length))),
+                )
+                .await
+                {
                     Err(_) => {
                         debug!("accept websocket stream timeout");
                     }
@@ -752,5 +768,105 @@ async fn extract_forwarded_for_from_ws_handshake(
             SocketAddr::new(ip, port)
         }
         None => fallback_address,
+    }
+}
+
+#[cfg(all(test, feature = "ws"))]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt, future::poll_fn};
+    use std::pin::Pin;
+    use tokio::io::{AsyncRead, ReadBuf};
+    use tokio_tungstenite::{client_async_with_config, tungstenite::Message};
+
+    const LENGTH_DELIMITED_PREFIX_LEN: usize = 4;
+
+    #[test]
+    fn websocket_accept_allows_message_at_configured_frame_limit_with_prefix() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let max_frame_length = 1024;
+            let message_len = max_frame_length + LENGTH_DELIMITED_PREFIX_LEN;
+
+            let data = read_websocket_message(max_frame_length, message_len)
+                .await
+                .expect("message at configured frame limit plus prefix must be accepted");
+
+            assert_eq!(data.len(), message_len);
+        });
+    }
+
+    #[test]
+    fn websocket_accept_rejects_messages_over_configured_frame_limit() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let max_frame_length = 1024;
+            let message_len = max_frame_length + LENGTH_DELIMITED_PREFIX_LEN + 1;
+
+            let err = read_websocket_message(max_frame_length, message_len)
+                .await
+                .expect_err("oversized websocket message must be rejected");
+
+            assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        });
+    }
+
+    async fn read_websocket_message(
+        max_frame_length: usize,
+        message_len: usize,
+    ) -> io::Result<Vec<u8>> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = tokio::spawn(async move {
+            let tcp = TcpStream::connect(addr).await.unwrap();
+            let url = format!("ws://{}", addr);
+            let (mut ws, _) = client_async_with_config(url, tcp, None).await.unwrap();
+            ws.send(Message::Binary(vec![0; message_len].into()))
+                .await
+                .unwrap();
+        });
+
+        let (server, remote_address) = listener.accept().await.unwrap();
+        let (sender, mut receiver) = mpsc::channel(1);
+        #[cfg(feature = "tls")]
+        let acceptor = TlsAcceptor::from(Arc::new(
+            ServerConfig::builder()
+                .with_no_client_auth()
+                .with_cert_resolver(Arc::new(ResolvesServerCertUsingSni::new())),
+        ));
+
+        let selector = tokio::spawn(protocol_select(
+            server,
+            Duration::from_secs(1),
+            UpgradeModeEnum::OnlyWs,
+            sender,
+            remote_address,
+            Arc::new(Vec::new()),
+            max_frame_length,
+            #[cfg(feature = "tls")]
+            acceptor,
+        ));
+
+        let (_addr, mut stream) = receiver.next().await.expect("websocket accepted");
+        let mut buf = vec![0u8; message_len];
+        let mut read_buf = ReadBuf::new(&mut buf);
+        let result = poll_fn(|cx| Pin::new(&mut stream).poll_read(cx, &mut read_buf)).await;
+        let filled = read_buf.filled().to_vec();
+
+        client.await.unwrap();
+        selector.await.unwrap();
+
+        result.map(|_| filled)
     }
 }

--- a/tentacle/src/transports/ws.rs
+++ b/tentacle/src/transports/ws.rs
@@ -11,7 +11,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_tungstenite::{
     WebSocketStream, client_async_with_config,
-    tungstenite::{Error, Message},
+    tungstenite::{Error, Message, protocol::WebSocketConfig},
 };
 
 use crate::{
@@ -23,12 +23,24 @@ use crate::{
     utils::{dns::DnsResolver, multiaddr_to_socketaddr},
 };
 
+// LengthDelimitedCodec prefixes each payload with a 4-byte length field.
+const LENGTH_DELIMITED_PREFIX_LEN: usize = 4;
+
+pub(crate) fn websocket_config(max_frame_length: usize) -> WebSocketConfig {
+    let max_message_length = max_frame_length.saturating_add(LENGTH_DELIMITED_PREFIX_LEN);
+
+    WebSocketConfig::default()
+        .max_message_size(Some(max_message_length))
+        .max_frame_size(Some(max_message_length))
+}
+
 /// websocket connect
 async fn connect(
     address: impl Future<Output = Result<Multiaddr>>,
     timeout: Duration,
     original: Option<Multiaddr>,
     tcp_config: TcpSocketConfig,
+    max_frame_length: usize,
 ) -> Result<(Multiaddr, WsStream)> {
     let addr = address.await?;
     match multiaddr_to_socketaddr(&addr) {
@@ -36,7 +48,12 @@ async fn connect(
             let url = format!("ws://{}:{}", socket_address.ip(), socket_address.port());
             let tcp = tcp_dial(socket_address, tcp_config, timeout).await?;
 
-            match crate::runtime::timeout(timeout, client_async_with_config(url, tcp, None)).await {
+            match crate::runtime::timeout(
+                timeout,
+                client_async_with_config(url, tcp, Some(websocket_config(max_frame_length))),
+            )
+            .await
+            {
                 Err(_) => Err(TransportErrorKind::Io(io::ErrorKind::TimedOut.into())),
                 Ok(res) => Ok((original.unwrap_or(addr), {
                     let (stream, _) = res.map_err(|err| {
@@ -57,13 +74,15 @@ async fn connect(
 pub struct WsTransport {
     timeout: Duration,
     tcp_config: TcpSocketConfig,
+    max_frame_length: usize,
 }
 
 impl WsTransport {
-    pub fn new(timeout: Duration, tcp_config: TcpSocketConfig) -> Self {
+    pub fn new(timeout: Duration, tcp_config: TcpSocketConfig, max_frame_length: usize) -> Self {
         WsTransport {
             timeout,
             tcp_config,
+            max_frame_length,
         }
     }
 }
@@ -86,11 +105,18 @@ impl TransportDial for WsTransport {
                     self.timeout,
                     Some(address),
                     self.tcp_config,
+                    self.max_frame_length,
                 );
                 Ok(TransportFuture::new(Box::pin(task)))
             }
             None => {
-                let dial = connect(ok(address), self.timeout, None, self.tcp_config);
+                let dial = connect(
+                    ok(address),
+                    self.timeout,
+                    None,
+                    self.tcp_config,
+                    self.max_frame_length,
+                );
                 Ok(TransportFuture::new(Box::pin(dial)))
             }
         }
@@ -284,5 +310,19 @@ impl AsyncWrite for WsStream {
             .as_mut()
             .poll_close(cx)
             .map_err(|_| io::ErrorKind::BrokenPipe.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::config::TcpSocketConfig;
+    use std::time::Duration;
+
+    #[test]
+    fn ws_transport_remembers_configured_frame_limit() {
+        let transport = WsTransport::new(Duration::from_secs(1), TcpSocketConfig::default(), 2048);
+
+        assert_eq!(transport.max_frame_length, 2048);
     }
 }


### PR DESCRIPTION
## Summary

- Propagate `ServiceConfig::max_frame_length` into WebSocket transport setup.
- Configure tungstenite `max_message_size` and `max_frame_size` for both inbound and outbound WebSocket handshakes.
- Add regression coverage for rejecting WebSocket messages over the configured frame limit.

## Root Cause

WebSocket connections used tungstenite's default message and frame limits before Tentacle's own framing layer was reached. That meant a peer could send a WebSocket message larger than Tentacle's configured `max_frame_length`, and tungstenite could accept and buffer it before the later Tentacle frame-size check rejected it.

## Impact

Oversized WebSocket frames/messages are now rejected at the WebSocket parser boundary. Plain TCP behavior is unchanged at the transport layer and continues to rely on the existing Tentacle session framing limit.

This does not change the public API. It does intentionally make oversized WebSocket input fail earlier.

## Validation

- `make ci`