### PR TITLE
Keep raw inbound handshakes alive during idle shutdown

### DIFF
--- a/tentacle/src/service.rs
+++ b/tentacle/src/service.rs
@@ -519,6 +519,7 @@ where
                         event_sender: sender,
                         max_frame_length,
                         timeout,
+                        tracked_state: true,
                     }
                     .handshake(incoming)
                     .await;
@@ -904,6 +905,7 @@ where
             event_sender: self.session_event_sender.clone(),
             max_frame_length: self.config.max_frame_length,
             timeout: self.config.timeout.timeout,
+            tracked_state: true,
         }
         .handshake(socket);
 
@@ -1387,8 +1389,9 @@ where
                 address,
                 ty,
                 listen_address,
+                tracked_state,
             } => {
-                if ty.is_outbound() {
+                if tracked_state {
                     self.state.decrease();
                 }
                 if !self.reached_max_connection_limit() {
@@ -1417,9 +1420,16 @@ where
                         .close(0u32.into(), b"capacity");
                 }
             }
-            SessionEvent::HandshakeError { ty, error, address } => {
-                if ty.is_outbound() {
+            SessionEvent::HandshakeError {
+                ty,
+                error,
+                address,
+                tracked_state,
+            } => {
+                if tracked_state {
                     self.state.decrease();
+                }
+                if ty.is_outbound() {
                     self.dial_protocols.remove(&address);
                     let _ignore = self
                         .handle_sender
@@ -1668,6 +1678,7 @@ where
             } => {
                 let (ty, listen_addr) = match session_info {
                     RawSessionInfo::Inbound { listen_addr } => {
+                        self.state.increase();
                         (SessionType::Inbound, Some(listen_addr))
                     }
                     RawSessionInfo::Outbound { target } => {
@@ -1826,5 +1837,40 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServiceTask;
+    use crate::{
+        builder::ServiceBuilder,
+        channel::mpsc::Priority,
+        multiaddr::Multiaddr,
+        secio::SecioKeyPair,
+        service::{RawSessionInfo, Service, config::State},
+    };
+
+    #[tokio::test]
+    async fn raw_inbound_session_registers_pending_work() {
+        let mut service: Service<(), SecioKeyPair> = ServiceBuilder::default().build(());
+        let mut inner = service.inner_service.take().expect("inner service");
+        let (raw_session, _peer) = tokio::io::duplex(64);
+        let remote_address: Multiaddr = "/memory/1".parse().unwrap();
+        let listen_addr: Multiaddr = "/memory/2".parse().unwrap();
+
+        inner
+            .handle_service_task(
+                ServiceTask::RawSession {
+                    remote_address,
+                    raw_session: Box::new(raw_session),
+                    session_info: RawSessionInfo::inbound(listen_addr),
+                },
+                Priority::Normal,
+            )
+            .await;
+
+        assert_eq!(inner.state, State::Running(1));
+        assert!(!inner.state.is_shutdown());
     }
 }

--- a/tentacle/src/service/helper.rs
+++ b/tentacle/src/service/helper.rs
@@ -80,6 +80,7 @@ pub(crate) struct HandshakeContext<K> {
     pub(crate) ty: SessionType,
     pub(crate) remote_address: Multiaddr,
     pub(crate) listen_address: Option<Multiaddr>,
+    pub(crate) tracked_state: bool,
 }
 
 impl<K> HandshakeContext<K>
@@ -111,6 +112,7 @@ where
                             ty: self.ty,
                             error: HandshakeErrorKind::Timeout(error.to_string()),
                             address: self.remote_address,
+                            tracked_state: self.tracked_state,
                         }
                     }
                     Ok(res) => match res {
@@ -120,6 +122,7 @@ where
                             address: self.remote_address,
                             ty: self.ty,
                             listen_address: self.listen_address,
+                            tracked_state: self.tracked_state,
                         },
                         Err(error) => {
                             debug!(
@@ -130,6 +133,7 @@ where
                                 ty: self.ty,
                                 error: HandshakeErrorKind::SecioError(error),
                                 address: self.remote_address,
+                                tracked_state: self.tracked_state,
                             }
                         }
                     },
@@ -145,6 +149,7 @@ where
                     address: self.remote_address,
                     ty: self.ty,
                     listen_address: self.listen_address,
+                    tracked_state: self.tracked_state,
                 };
                 if let Err(err) = self.event_sender.send(event).await {
                     error!("handshake result send back error: {:?}", err);
@@ -395,6 +400,7 @@ where
             event_sender: self.event_sender.clone(),
             max_frame_length: self.max_frame_length,
             timeout: self.timeout,
+            tracked_state: false,
         }
         .handshake(socket);
 

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -75,6 +75,8 @@ pub(crate) enum SessionEvent {
         ty: SessionType,
         /// listen addr
         listen_address: Option<Multiaddr>,
+        /// Whether this handshake incremented the service pending-work state.
+        tracked_state: bool,
     },
     /// QUIC handshake completed (TLS + tentacle identity verified) for either
     /// a dial or accept. Bypasses the secio handshake path; the recipient
@@ -88,6 +90,8 @@ pub(crate) enum SessionEvent {
         ty: SessionType,
         /// error
         error: HandshakeErrorKind,
+        /// Whether this handshake incremented the service pending-work state.
+        tracked_state: bool,
     },
     DialError {
         /// remote address


### PR DESCRIPTION
### Summary

Fix an idle-shutdown race for inbound raw sessions.

`RawSessionInfo::Inbound` previously started a handshake without registering pending work in the service state. For services running with no listener, no active sessions, and `forever(false)`, the main loop could treat the service as idle and shut down before the inbound raw-session handshake completed.

### Changes

- Register inbound raw-session handshakes as pending work.
- Add a `tracked_state` flag to handshake events so only handshakes that incremented the service state release it on success or failure.
- Keep normal listener inbound handshakes untracked, preserving their existing state behavior.
- Add regression coverage for inbound raw sessions registering pending work.

### Tests

- `cargo fmt --check`
- `cargo test -p tentacle raw_inbound_session_registers_pending_work -- --nocapture`
- `git diff --check`