### PR TITLE
Rearm idle session timeout while substreams are active

### DIFF
--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -105,6 +105,7 @@ pub(crate) struct QuicSession {
 
     config: SessionConfig,
     timeout: Duration,
+    timeout_generation: u64,
     keep_buffer: bool,
     state: SessionState,
     context: Arc<SessionContext>,
@@ -156,10 +157,12 @@ impl QuicSession {
         // Channel between the session loop and the spawned substream tasks.
         let (proto_event_sender, proto_event_receiver) = mpsc::channel(meta.config.channel_size);
 
+        let timeout_generation = 1;
         Self::schedule_timeout_check(
             meta.timeout,
             proto_event_sender.clone(),
             future_task_sender.clone(),
+            timeout_generation,
         );
 
         QuicSession {
@@ -168,6 +171,7 @@ impl QuicSession {
             protocol_configs_by_id: meta.protocol_configs_by_id,
             config: meta.config,
             timeout: meta.timeout,
+            timeout_generation,
             context: meta.context,
             service_control: meta.service_control,
             keep_buffer: meta.keep_buffer,
@@ -251,6 +255,7 @@ impl QuicSession {
         timeout: Duration,
         mut proto_event_sender: mpsc::Sender<ProtocolEvent>,
         mut future_task_sender: mpsc::Sender<BoxedFutureTask>,
+        generation: u64,
     ) {
         // NOTE: A Interval/Delay will block tokio runtime from gracefully shutdown.
         //       So we spawn it in FutureTaskManager.
@@ -258,7 +263,7 @@ impl QuicSession {
             crate::runtime::delay_for(timeout).await;
             let task = Box::pin(async move {
                 if proto_event_sender
-                    .send(ProtocolEvent::TimeoutCheck)
+                    .send(ProtocolEvent::TimeoutCheck(generation))
                     .await
                     .is_err()
                 {
@@ -269,6 +274,16 @@ impl QuicSession {
                 trace!("timeout check task send err")
             }
         });
+    }
+
+    fn schedule_next_timeout_check(&mut self) {
+        self.timeout_generation = self.timeout_generation.wrapping_add(1);
+        Self::schedule_timeout_check(
+            self.timeout,
+            self.proto_event_sender.clone(),
+            self.future_task_sender.clone(),
+            self.timeout_generation,
+        );
     }
 
     /// Open a new substream and run client-side protocol negotiation on it.
@@ -476,6 +491,9 @@ impl QuicSession {
                 debug!("session [{}] proto [{}] closed", self.context.id, proto_id);
                 if self.substreams.remove(&id).is_some() {
                     self.proto_streams.remove(&proto_id);
+                    if self.substreams.is_empty() {
+                        self.schedule_next_timeout_check();
+                    }
                 }
             }
             ProtocolEvent::Message { .. } => unreachable!(),
@@ -499,7 +517,11 @@ impl QuicSession {
                     },
                 )
             }
-            ProtocolEvent::TimeoutCheck => {
+            ProtocolEvent::TimeoutCheck(generation) => {
+                if generation != self.timeout_generation {
+                    return;
+                }
+
                 if self.substreams.is_empty() {
                     self.event_output(
                         cx,
@@ -508,12 +530,6 @@ impl QuicSession {
                         },
                     );
                     self.state = SessionState::LocalClose;
-                } else {
-                    Self::schedule_timeout_check(
-                        self.timeout,
-                        self.proto_event_sender.clone(),
-                        self.future_task_sender.clone(),
-                    );
                 }
             }
         }

--- a/tentacle/src/quic/session.rs
+++ b/tentacle/src/quic/session.rs
@@ -156,22 +156,11 @@ impl QuicSession {
         // Channel between the session loop and the spawned substream tasks.
         let (proto_event_sender, proto_event_receiver) = mpsc::channel(meta.config.channel_size);
 
-        // Schedule a one-shot timeout-check tick so dangling sessions with no
-        // substream activity get garbage-collected. Mirrors the yamux session.
-        let mut interval = proto_event_sender.clone();
-        let mut future_task_sender_ = future_task_sender.clone();
-        let timeout = meta.timeout;
-        crate::runtime::spawn(async move {
-            crate::runtime::delay_for(timeout).await;
-            let task = Box::pin(async move {
-                if interval.send(ProtocolEvent::TimeoutCheck).await.is_err() {
-                    trace!("timeout check send err")
-                }
-            });
-            if future_task_sender_.send(task).await.is_err() {
-                trace!("timeout check task send err")
-            }
-        });
+        Self::schedule_timeout_check(
+            meta.timeout,
+            proto_event_sender.clone(),
+            future_task_sender.clone(),
+        );
 
         QuicSession {
             conn,
@@ -254,6 +243,30 @@ impl QuicSession {
         crate::runtime::spawn(async move {
             if future_task_sender.send(task).await.is_err() {
                 trace!("select procedure send err")
+            }
+        });
+    }
+
+    fn schedule_timeout_check(
+        timeout: Duration,
+        mut proto_event_sender: mpsc::Sender<ProtocolEvent>,
+        mut future_task_sender: mpsc::Sender<BoxedFutureTask>,
+    ) {
+        // NOTE: A Interval/Delay will block tokio runtime from gracefully shutdown.
+        //       So we spawn it in FutureTaskManager.
+        crate::runtime::spawn(async move {
+            crate::runtime::delay_for(timeout).await;
+            let task = Box::pin(async move {
+                if proto_event_sender
+                    .send(ProtocolEvent::TimeoutCheck)
+                    .await
+                    .is_err()
+                {
+                    trace!("timeout check send err")
+                }
+            });
+            if future_task_sender.send(task).await.is_err() {
+                trace!("timeout check task send err")
             }
         });
     }
@@ -495,6 +508,12 @@ impl QuicSession {
                         },
                     );
                     self.state = SessionState::LocalClose;
+                } else {
+                    Self::schedule_timeout_check(
+                        self.timeout,
+                        self.proto_event_sender.clone(),
+                        self.future_task_sender.clone(),
+                    );
                 }
             }
         }

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -214,23 +214,11 @@ impl Session {
         let socket = YamuxSession::new(socket, meta.config.yamux_config, meta.context.ty.into());
         let control = socket.control();
         let (proto_event_sender, proto_event_receiver) = mpsc::channel(meta.config.channel_size);
-        let mut interval = proto_event_sender.clone();
-
-        // NOTE: A Interval/Delay will block tokio runtime from gracefully shutdown.
-        //       So we spawn it in FutureTaskManager
-        let mut future_task_sender_ = future_task_sender.clone();
-        let timeout = meta.timeout;
-        crate::runtime::spawn(async move {
-            crate::runtime::delay_for(timeout).await;
-            let task = Box::pin(async move {
-                if interval.send(ProtocolEvent::TimeoutCheck).await.is_err() {
-                    trace!("timeout check send err")
-                }
-            });
-            if future_task_sender_.send(task).await.is_err() {
-                trace!("timeout check task send err")
-            }
-        });
+        Self::schedule_timeout_check(
+            meta.timeout,
+            proto_event_sender.clone(),
+            future_task_sender.clone(),
+        );
         // background inner socket
         let sid = meta.context.id;
         crate::runtime::spawn(
@@ -558,6 +546,12 @@ impl Session {
                         },
                     );
                     self.state = SessionState::LocalClose;
+                } else {
+                    Self::schedule_timeout_check(
+                        self.timeout,
+                        self.proto_event_sender.clone(),
+                        self.future_task_sender.clone(),
+                    );
                 }
             }
         }
@@ -730,6 +724,30 @@ impl Session {
         } else {
             Poll::Pending
         }
+    }
+
+    fn schedule_timeout_check(
+        timeout: Duration,
+        mut proto_event_sender: mpsc::Sender<ProtocolEvent>,
+        mut future_task_sender: mpsc::Sender<BoxedFutureTask>,
+    ) {
+        // NOTE: A Interval/Delay will block tokio runtime from gracefully shutdown.
+        //       So we spawn it in FutureTaskManager.
+        crate::runtime::spawn(async move {
+            crate::runtime::delay_for(timeout).await;
+            let task = Box::pin(async move {
+                if proto_event_sender
+                    .send(ProtocolEvent::TimeoutCheck)
+                    .await
+                    .is_err()
+                {
+                    trace!("timeout check send err")
+                }
+            });
+            if future_task_sender.send(task).await.is_err() {
+                trace!("timeout check task send err")
+            }
+        });
     }
 
     /// Clean env

--- a/tentacle/src/session.rs
+++ b/tentacle/src/session.rs
@@ -168,6 +168,7 @@ pub(crate) struct Session {
     config: SessionConfig,
 
     timeout: Duration,
+    timeout_generation: u64,
 
     keep_buffer: bool,
 
@@ -214,10 +215,12 @@ impl Session {
         let socket = YamuxSession::new(socket, meta.config.yamux_config, meta.context.ty.into());
         let control = socket.control();
         let (proto_event_sender, proto_event_receiver) = mpsc::channel(meta.config.channel_size);
+        let timeout_generation = 1;
         Self::schedule_timeout_check(
             meta.timeout,
             proto_event_sender.clone(),
             future_task_sender.clone(),
+            timeout_generation,
         );
         // background inner socket
         let sid = meta.context.id;
@@ -231,6 +234,7 @@ impl Session {
             protocol_configs_by_id: meta.protocol_configs_by_id,
             config: meta.config,
             timeout: meta.timeout,
+            timeout_generation,
             context: meta.context,
             service_control: meta.service_control,
             keep_buffer: meta.keep_buffer,
@@ -514,6 +518,9 @@ impl Session {
                 debug!("session [{}] proto [{}] closed", self.context.id, proto_id);
                 if self.substreams.remove(&id).is_some() {
                     self.proto_streams.remove(&proto_id);
+                    if self.substreams.is_empty() {
+                        self.schedule_next_timeout_check();
+                    }
                 }
             }
             ProtocolEvent::Message { .. } => unreachable!(),
@@ -537,7 +544,11 @@ impl Session {
                     },
                 )
             }
-            ProtocolEvent::TimeoutCheck => {
+            ProtocolEvent::TimeoutCheck(generation) => {
+                if generation != self.timeout_generation {
+                    return;
+                }
+
                 if self.substreams.is_empty() {
                     self.event_output(
                         cx,
@@ -546,12 +557,6 @@ impl Session {
                         },
                     );
                     self.state = SessionState::LocalClose;
-                } else {
-                    Self::schedule_timeout_check(
-                        self.timeout,
-                        self.proto_event_sender.clone(),
-                        self.future_task_sender.clone(),
-                    );
                 }
             }
         }
@@ -730,6 +735,7 @@ impl Session {
         timeout: Duration,
         mut proto_event_sender: mpsc::Sender<ProtocolEvent>,
         mut future_task_sender: mpsc::Sender<BoxedFutureTask>,
+        generation: u64,
     ) {
         // NOTE: A Interval/Delay will block tokio runtime from gracefully shutdown.
         //       So we spawn it in FutureTaskManager.
@@ -737,7 +743,7 @@ impl Session {
             crate::runtime::delay_for(timeout).await;
             let task = Box::pin(async move {
                 if proto_event_sender
-                    .send(ProtocolEvent::TimeoutCheck)
+                    .send(ProtocolEvent::TimeoutCheck(generation))
                     .await
                     .is_err()
                 {
@@ -748,6 +754,16 @@ impl Session {
                 trace!("timeout check task send err")
             }
         });
+    }
+
+    fn schedule_next_timeout_check(&mut self) {
+        self.timeout_generation = self.timeout_generation.wrapping_add(1);
+        Self::schedule_timeout_check(
+            self.timeout,
+            self.proto_event_sender.clone(),
+            self.future_task_sender.clone(),
+            self.timeout_generation,
+        );
     }
 
     /// Clean env

--- a/tentacle/src/substream.rs
+++ b/tentacle/src/substream.rs
@@ -109,7 +109,7 @@ pub(crate) enum ProtocolEvent {
         /// Codec error
         error: std::io::Error,
     },
-    TimeoutCheck,
+    TimeoutCheck(u64),
 }
 
 /// Each custom protocol in a session corresponds to a sub stream

--- a/tentacle/tests/test_idle_session_timeout.rs
+++ b/tentacle/tests/test_idle_session_timeout.rs
@@ -1,0 +1,208 @@
+//! Regression test for the "empty yamux session can persist indefinitely"
+//! security fix.
+//!
+//! Scenario reproduced by this test:
+//!   1. A peer connects and negotiates a protocol.
+//!   2. The peer keeps the protocol substream open past the session `timeout`
+//!      so the initial one-shot timeout check fires while a substream still
+//!      exists (the pre-fix code path that leaked idle sessions).
+//!   3. The peer then closes the last protocol substream while keeping the
+//!      underlying transport alive.
+//!   4. The fixed code re-arms the session timeout the moment `substreams`
+//!      becomes empty. After another `timeout` interval the session must be
+//!      reaped, emitting `ServiceError::SessionTimeout` and then closing the
+//!      session cleanly.
+//!
+//! Without the fix, step 3 would leave the session/yamux/TCP connection
+//! alive indefinitely and neither `SessionTimeout` nor `SessionClose` would
+//! be observed after the last protocol was closed.
+
+use futures::channel;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+use tentacle::{
+    ProtocolId, async_trait,
+    builder::{MetaBuilder, ServiceBuilder},
+    context::{ProtocolContextMutRef, ServiceContext},
+    multiaddr::Multiaddr,
+    secio::SecioKeyPair,
+    service::{ProtocolHandle, ProtocolMeta, Service, ServiceError, ServiceEvent, TargetProtocol},
+    traits::{ServiceHandle, SessionProtocol},
+};
+
+const SESSION_TIMEOUT: Duration = Duration::from_secs(2);
+/// Wait strictly longer than SESSION_TIMEOUT before closing the protocol so
+/// that the initial (session-open) timeout check has already been consumed
+/// while `substreams` was non-empty — this is exactly the pre-fix leak
+/// scenario.
+const CLOSE_AFTER: Duration = Duration::from_millis(2500);
+
+fn create<F>(secio: bool, meta: ProtocolMeta, shandle: F) -> Service<F, SecioKeyPair>
+where
+    F: ServiceHandle + Unpin + 'static,
+{
+    let builder = ServiceBuilder::default()
+        .insert_protocol(meta)
+        .forever(true)
+        .timeout(SESSION_TIMEOUT);
+
+    if secio {
+        builder
+            .handshake_type(SecioKeyPair::secp256k1_generated().into())
+            .build(shandle)
+    } else {
+        builder.build(shandle)
+    }
+}
+
+/// Client-side protocol handler: after `connected`, arms a one-shot notify
+/// that will close the protocol substream once the initial session timeout
+/// window has already elapsed.
+struct ClientProto;
+
+#[async_trait]
+impl SessionProtocol for ClientProto {
+    async fn connected(&mut self, context: ProtocolContextMutRef<'_>, _version: &str) {
+        // Schedule a single notify that fires after the initial session-open
+        // timeout has been consumed.
+        context
+            .set_session_notify(context.session.id, context.proto_id, CLOSE_AFTER, 1)
+            .await
+            .ok();
+    }
+
+    async fn notify(&mut self, context: ProtocolContextMutRef<'_>, token: u64) {
+        if token == 1 {
+            // Close the last (and only) protocol substream while keeping the
+            // TCP/yamux transport open. In the pre-fix code this leaves an
+            // idle protocol-less session alive forever.
+            context
+                .close_protocol(context.session.id, context.proto_id)
+                .await
+                .ok();
+        }
+    }
+}
+
+/// Server-side `ServiceHandle`: observes `ServiceError::SessionTimeout` and
+/// `ServiceEvent::SessionClose` and forwards the observation on a channel.
+#[derive(Clone)]
+struct ServerHandle {
+    saw_session_timeout: Arc<AtomicBool>,
+    close_sender: crossbeam_channel::Sender<()>,
+}
+
+#[async_trait]
+impl ServiceHandle for ServerHandle {
+    async fn handle_error(&mut self, _control: &mut ServiceContext, error: ServiceError) {
+        if let ServiceError::SessionTimeout { .. } = error {
+            self.saw_session_timeout.store(true, Ordering::SeqCst);
+        }
+    }
+
+    async fn handle_event(&mut self, _control: &mut ServiceContext, event: ServiceEvent) {
+        if let ServiceEvent::SessionClose { .. } = event {
+            self.close_sender.try_send(()).ok();
+        }
+    }
+}
+
+fn create_meta(id: ProtocolId, client: bool) -> ProtocolMeta {
+    if client {
+        MetaBuilder::new()
+            .id(id)
+            .session_handle(move || ProtocolHandle::Callback(Box::new(ClientProto)))
+            .build()
+    } else {
+        // The server-side protocol does nothing on its own; the client
+        // drives open/close so the server must reap the idle session
+        // via the re-armed timeout.
+        MetaBuilder::new().id(id).build()
+    }
+}
+
+fn test_idle_session_reaped_after_last_protocol_close(secio: bool) {
+    let saw_session_timeout = Arc::new(AtomicBool::new(false));
+    let (close_sender, close_receiver) = crossbeam_channel::unbounded();
+    let (addr_sender, addr_receiver) = channel::oneshot::channel::<Multiaddr>();
+
+    // --- server -------------------------------------------------------------
+    let server_handle = ServerHandle {
+        saw_session_timeout: saw_session_timeout.clone(),
+        close_sender,
+    };
+    thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(secio, create_meta(1.into(), false), server_handle);
+        rt.block_on(async move {
+            let listen_addr = service
+                .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+                .await
+                .unwrap();
+            addr_sender.send(listen_addr).ok();
+            service.run().await;
+        });
+    });
+
+    // --- client -------------------------------------------------------------
+    thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut service = create(secio, create_meta(1.into(), true), ());
+        rt.block_on(async move {
+            let listen_addr = addr_receiver.await.unwrap();
+            service
+                .dial(listen_addr, TargetProtocol::All)
+                .await
+                .unwrap();
+            service.run().await;
+        });
+    });
+
+    // The full sequence is:
+    //   - open protocol
+    //   - wait CLOSE_AFTER (> SESSION_TIMEOUT) — during this window the
+    //     initial one-shot timer fires but is a no-op because substreams != 0
+    //   - client closes protocol → substreams becomes empty → new timer armed
+    //   - after another SESSION_TIMEOUT the server observes SessionTimeout
+    //     and then SessionClose.
+    let overall_budget = CLOSE_AFTER + SESSION_TIMEOUT + Duration::from_secs(5);
+    let deadline = Instant::now() + overall_budget;
+
+    let mut got_close = false;
+    while Instant::now() < deadline {
+        if close_receiver
+            .recv_timeout(Duration::from_millis(200))
+            .is_ok()
+        {
+            got_close = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_session_timeout.load(Ordering::SeqCst),
+        "server never observed ServiceError::SessionTimeout after the last protocol was closed; \
+         idle session was leaked"
+    );
+    assert!(
+        got_close,
+        "server never observed ServiceEvent::SessionClose after the idle timeout; \
+         idle session was leaked"
+    );
+}
+
+#[test]
+fn test_idle_session_reaped_after_last_protocol_close_with_secio() {
+    test_idle_session_reaped_after_last_protocol_close(true);
+}
+
+#[test]
+fn test_idle_session_reaped_after_last_protocol_close_with_no_secio() {
+    test_idle_session_reaped_after_last_protocol_close(false);
+}


### PR DESCRIPTION
## Summary

- rearm the session timeout check when it fires while protocol substreams are still active
- keep protocol open/close semantics unchanged while ensuring protocol-less sessions are eventually reaped
- apply the same timeout behavior to both yamux and QUIC sessions

## Motivation

The previous timeout check was effectively one-shot. If it fired while a protocol substream was open, the check was consumed and never scheduled again. After the final protocol substream closed, the session could remain alive indefinitely without active protocols.

## Tests

- `cargo fmt --all`
- `cargo test -p tentacle --lib --features tokio-runtime`