### PR TITLE
fix: invert identify timeout condition — timeout silent peers, not identified ones

### DIFF
--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -329,7 +329,7 @@ impl<T: Callback> ServiceProtocol for IdentifyProtocol<T> {
         }
 
         for (session_id, info) in &self.remote_infos {
-            if info.has_received && (info.connected_at + info.timeout) <= Instant::now() {
+            if !info.has_received && (info.connected_at + info.timeout) <= Instant::now() {
                 debug!("{:?} receive identify message timeout", info.peer_id);
                 if self
                     .callback


### PR DESCRIPTION
## Summary

Fixes an inverted timeout condition in the identify protocol that causes silent peers to never be disconnected while well-behaved peers are falsely timed out.

## Problem

In `protocols/identify/src/lib.rs`, the timeout check uses `info.has_received && expired`:

- `has_received` starts as `false` and is only set to `true` after a valid identify message arrives
- This means **silent peers** (`has_received = false`) are **never timed out**, allowing resource exhaustion
- **Well-behaved peers** that successfully identify (`has_received = true`) are **falsely disconnected** after the timeout deadline

This is the opposite of the intended behavior. The original logic before the refactoring was `(info.listen_addrs.is_none() || info.observed_addr.is_none()) && expired` — only timing out peers that had NOT completed identify.

## Fix

One character change — negate the `has_received` condition:

```rust
// Before: timeout peers that DID identify (wrong)
if info.has_received && (info.connected_at + info.timeout) <= Instant::now() {

// After: timeout peers that have NOT identified (correct)
if !info.has_received && (info.connected_at + info.timeout) <= Instant::now() {
```

| Scenario | Before (bug) | After (fix) |
|---|---|---|
| Silent peer, never sends identify | Never disconnected | Disconnected after ~8s |
| Well-behaved peer, sends identify | Falsely disconnected after ~8s | Left alone |

The identify protocol is a one-time handshake — once complete, it has no reason to time the peer out. Idle/unresponsive peers after identify are handled by other layers (TCP keepalive, yamux pings, app-level heartbeats).